### PR TITLE
Refactor IO traits

### DIFF
--- a/utils-aio/src/codec.rs
+++ b/utils-aio/src/codec.rs
@@ -4,8 +4,8 @@ use tokio_serde::formats::Bincode;
 use tokio_util::{codec::LengthDelimitedCodec, compat::FuturesAsyncReadCompatExt};
 
 use crate::{
+    duplex::Duplex,
     mux::{MuxChannelSerde, MuxStream, MuxerError},
-    Channel,
 };
 
 /// Wraps a [`MuxStream`] and provides a [`Channel`] with a bincode codec
@@ -25,7 +25,7 @@ where
     pub fn attach_codec<S: AsyncWrite + AsyncRead + Send + Sync + Unpin + 'static, T>(
         &self,
         stream: S,
-    ) -> impl Channel<T>
+    ) -> impl Duplex<T>
     where
         T: serde::Serialize + for<'a> serde::Deserialize<'a> + Send + Sync + Unpin + 'static,
     {
@@ -45,7 +45,7 @@ where
     >(
         &mut self,
         id: &str,
-    ) -> Result<Box<dyn Channel<T> + 'static>, MuxerError> {
+    ) -> Result<Box<dyn Duplex<T> + 'static>, MuxerError> {
         let stream = self.0.get_stream(id).await?;
 
         Ok(Box::new(self.attach_codec(stream)))

--- a/utils-aio/src/duplex.rs
+++ b/utils-aio/src/duplex.rs
@@ -1,33 +1,20 @@
 use std::{
-    io,
     io::{Error, ErrorKind},
     pin::Pin,
 };
 
 use futures::{channel::mpsc, AsyncRead, AsyncWrite, Sink, Stream};
 
+use crate::{sink::IoSink, stream::IoStream};
+
 pub trait DuplexByteStream: AsyncWrite + AsyncRead + Unpin {}
 
 impl<T> DuplexByteStream for T where T: AsyncWrite + AsyncRead + Unpin {}
 
 /// A channel that can be used to send and receive messages.
-pub trait Duplex<T>:
-    futures::Stream<Item = Result<T, io::Error>>
-    + futures::Sink<T, Error = io::Error>
-    + Send
-    + Sync
-    + Unpin
-{
-}
+pub trait Duplex<T>: IoStream<T> + IoSink<T> + Send + Sync + Unpin {}
 
-impl<T, U> Duplex<T> for U where
-    U: futures::Stream<Item = Result<T, io::Error>>
-        + futures::Sink<T, Error = io::Error>
-        + Send
-        + Sync
-        + Unpin
-{
-}
+impl<T, U> Duplex<T> for U where U: IoStream<T> + IoSink<T> + Send + Sync + Unpin {}
 
 #[derive(Debug)]
 pub struct MpscDuplex<T> {

--- a/utils-aio/src/duplex.rs
+++ b/utils-aio/src/duplex.rs
@@ -1,20 +1,122 @@
-use futures::{channel::mpsc, AsyncRead, AsyncWrite, Sink, Stream};
 use std::{
+    io,
     io::{Error, ErrorKind},
     pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::{
+    channel::mpsc, future::FusedFuture, stream::FusedStream, AsyncRead, AsyncWrite, Future, Sink,
+    Stream, TryStream, TryStreamExt,
 };
 
 pub trait DuplexByteStream: AsyncWrite + AsyncRead + Unpin {}
 
 impl<T> DuplexByteStream for T where T: AsyncWrite + AsyncRead + Unpin {}
 
+/// Future for the [`expect_next`](Duplex::expect_next) method.
 #[derive(Debug)]
-pub struct DuplexChannel<T> {
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct ExpectNext<'a, St: ?Sized> {
+    stream: &'a mut St,
+}
+
+impl<St: ?Sized + Unpin> Unpin for ExpectNext<'_, St> {}
+
+impl<'a, St: ?Sized + TryStream + Unpin> ExpectNext<'a, St> {
+    pub(super) fn new(stream: &'a mut St) -> Self {
+        Self { stream }
+    }
+}
+
+impl<St: ?Sized + TryStream + Unpin + FusedStream> FusedFuture for ExpectNext<'_, St>
+where
+    <St as TryStream>::Error: Into<io::Error>,
+{
+    fn is_terminated(&self) -> bool {
+        self.stream.is_terminated()
+    }
+}
+
+impl<St: ?Sized + TryStream + Unpin> Future for ExpectNext<'_, St>
+where
+    <St as TryStream>::Error: Into<io::Error>,
+{
+    type Output = io::Result<St::Ok>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.stream
+            .try_poll_next_unpin(cx)
+            .map_err(|e| e.into())?
+            .map(|item| {
+                if let Some(item) = item {
+                    Ok(item)
+                } else {
+                    Err(io::ErrorKind::UnexpectedEof.into())
+                }
+            })
+    }
+}
+
+/// A channel that can be used to send and receive messages.
+pub trait Duplex<T>:
+    futures::Stream<Item = Result<T, io::Error>>
+    + futures::Sink<T, Error = io::Error>
+    + Send
+    + Sync
+    + Unpin
+{
+    /// Creates a future that attempts to resolve the next item in the stream.
+    /// If an error is encountered before the next item, the error is returned
+    /// instead.
+    ///
+    /// Additionally, if the stream ends before the next item, an error is
+    /// returned.
+    ///
+    /// This is similar to the [`TryStreamExt::try_next`](futures::stream::TryStreamExt::try_next)
+    /// combinator, but returns an error if the stream ends before the next item instead of an
+    /// `Option`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # futures::executor::block_on(async {
+    /// use futures::{SinkExt, StreamExt};
+    /// use utils_aio::duplex::{Duplex, MpscDuplex};
+    ///
+    /// let (mut a, mut b) = MpscDuplex::new();
+    ///
+    /// a.send(()).await.unwrap();
+    /// a.close().await.unwrap();
+    ///
+    /// assert!(b.expect_next().await.is_ok());
+    /// assert!(b.expect_next().await.is_err());
+    /// # })
+    /// ```
+    fn expect_next(&mut self) -> ExpectNext<'_, Self>
+    where
+        Self: Sized,
+    {
+        ExpectNext::new(self)
+    }
+}
+
+impl<T, U> Duplex<T> for U where
+    U: futures::Stream<Item = Result<T, io::Error>>
+        + futures::Sink<T, Error = io::Error>
+        + Send
+        + Sync
+        + Unpin
+{
+}
+
+#[derive(Debug)]
+pub struct MpscDuplex<T> {
     sink: mpsc::Sender<T>,
     stream: mpsc::Receiver<T>,
 }
 
-impl<T> DuplexChannel<T>
+impl<T> MpscDuplex<T>
 where
     T: Send + 'static,
 {
@@ -34,7 +136,7 @@ where
     }
 }
 
-impl<T> Sink<T> for DuplexChannel<T>
+impl<T> Sink<T> for MpscDuplex<T>
 where
     T: Send + 'static,
 {
@@ -46,13 +148,13 @@ where
     ) -> std::task::Poll<Result<(), Self::Error>> {
         Pin::new(&mut self.sink)
             .poll_ready(cx)
-            .map_err(|_| Error::new(ErrorKind::ConnectionAborted, "channel died"))
+            .map_err(|e| Error::new(ErrorKind::ConnectionAborted, e.to_string()))
     }
 
     fn start_send(mut self: std::pin::Pin<&mut Self>, item: T) -> Result<(), Self::Error> {
         Pin::new(&mut self.sink)
             .start_send(item)
-            .map_err(|_| Error::new(ErrorKind::ConnectionAborted, "channel died"))
+            .map_err(|e| Error::new(ErrorKind::ConnectionAborted, e.to_string()))
     }
 
     fn poll_flush(
@@ -61,7 +163,7 @@ where
     ) -> std::task::Poll<Result<(), Self::Error>> {
         Pin::new(&mut self.sink)
             .poll_flush(cx)
-            .map_err(|_| Error::new(ErrorKind::ConnectionAborted, "channel died"))
+            .map_err(|e| Error::new(ErrorKind::ConnectionAborted, e.to_string()))
     }
 
     fn poll_close(
@@ -70,11 +172,11 @@ where
     ) -> std::task::Poll<Result<(), Self::Error>> {
         Pin::new(&mut self.sink)
             .poll_close(cx)
-            .map_err(|_| Error::new(ErrorKind::ConnectionAborted, "channel died"))
+            .map_err(|e| Error::new(ErrorKind::ConnectionAborted, e.to_string()))
     }
 }
 
-impl<T> Stream for DuplexChannel<T> {
+impl<T> Stream for MpscDuplex<T> {
     type Item = Result<T, std::io::Error>;
 
     fn poll_next(

--- a/utils-aio/src/duplex.rs
+++ b/utils-aio/src/duplex.rs
@@ -17,12 +17,12 @@ pub trait Duplex<T>: IoStream<T> + IoSink<T> + Send + Sync + Unpin {}
 impl<T, U> Duplex<T> for U where U: IoStream<T> + IoSink<T> + Send + Sync + Unpin {}
 
 #[derive(Debug)]
-pub struct MpscDuplex<T> {
+pub struct MemoryDuplex<T> {
     sink: mpsc::Sender<T>,
     stream: mpsc::Receiver<T>,
 }
 
-impl<T> MpscDuplex<T>
+impl<T> MemoryDuplex<T>
 where
     T: Send + 'static,
 {
@@ -42,7 +42,7 @@ where
     }
 }
 
-impl<T> Sink<T> for MpscDuplex<T>
+impl<T> Sink<T> for MemoryDuplex<T>
 where
     T: Send + 'static,
 {
@@ -82,7 +82,7 @@ where
     }
 }
 
-impl<T> Stream for MpscDuplex<T> {
+impl<T> Stream for MemoryDuplex<T> {
     type Item = Result<T, std::io::Error>;
 
     fn poll_next(

--- a/utils-aio/src/lib.rs
+++ b/utils-aio/src/lib.rs
@@ -11,3 +11,13 @@ pub mod mux;
 pub mod non_blocking_backend;
 pub mod sink;
 pub mod stream;
+
+/// Trait implemented by a type which can provide a duplex channel.
+#[cfg(feature = "duplex")]
+pub trait IoProvider<T> {
+    /// The type of the duplex channel.
+    type Duplex: duplex::Duplex<T>;
+
+    /// Provides a duplex channel.
+    fn provide_io(&mut self) -> &mut Self::Duplex;
+}

--- a/utils-aio/src/lib.rs
+++ b/utils-aio/src/lib.rs
@@ -9,21 +9,3 @@ pub mod factory;
 #[cfg(feature = "mux")]
 pub mod mux;
 pub mod non_blocking_backend;
-
-pub trait Channel<T>:
-    futures::Stream<Item = Result<T, std::io::Error>>
-    + futures::Sink<T, Error = std::io::Error>
-    + Send
-    + Sync
-    + Unpin
-{
-}
-
-impl<T, U> Channel<T> for U where
-    U: futures::Stream<Item = Result<T, std::io::Error>>
-        + futures::Sink<T, Error = std::io::Error>
-        + Send
-        + Sync
-        + Unpin
-{
-}

--- a/utils-aio/src/lib.rs
+++ b/utils-aio/src/lib.rs
@@ -11,13 +11,3 @@ pub mod mux;
 pub mod non_blocking_backend;
 pub mod sink;
 pub mod stream;
-
-/// Trait implemented by a type which can provide a duplex channel.
-#[cfg(feature = "duplex")]
-pub trait IoProvider<T> {
-    /// The type of the duplex channel.
-    type Duplex: duplex::Duplex<T>;
-
-    /// Provides a duplex channel.
-    fn provide_io(&mut self) -> &mut Self::Duplex;
-}

--- a/utils-aio/src/lib.rs
+++ b/utils-aio/src/lib.rs
@@ -9,3 +9,4 @@ pub mod factory;
 #[cfg(feature = "mux")]
 pub mod mux;
 pub mod non_blocking_backend;
+pub mod stream;

--- a/utils-aio/src/lib.rs
+++ b/utils-aio/src/lib.rs
@@ -9,4 +9,5 @@ pub mod factory;
 #[cfg(feature = "mux")]
 pub mod mux;
 pub mod non_blocking_backend;
+pub mod sink;
 pub mod stream;

--- a/utils-aio/src/mux.rs
+++ b/utils-aio/src/mux.rs
@@ -1,6 +1,7 @@
-use super::Channel;
 use async_trait::async_trait;
 use futures_util::{AsyncRead, AsyncWrite};
+
+use crate::duplex::Duplex;
 
 #[derive(Debug, thiserror::Error)]
 pub enum MuxerError {
@@ -30,7 +31,7 @@ pub trait MuxChannelSerde: Sized {
     >(
         &mut self,
         id: &str,
-    ) -> Result<Box<dyn Channel<T> + 'static>, MuxerError>;
+    ) -> Result<Box<dyn Duplex<T> + 'static>, MuxerError>;
 }
 
 /// A trait for opening a new duplex channel with a remote peer.
@@ -41,7 +42,7 @@ pub trait MuxChannel<T> {
     /// Opens a new channel with the remote using the provided id
     ///
     /// Attaches a codec to the underlying stream
-    async fn get_channel(&mut self, id: &str) -> Result<Box<dyn Channel<T> + 'static>, MuxerError>;
+    async fn get_channel(&mut self, id: &str) -> Result<Box<dyn Duplex<T> + 'static>, MuxerError>;
 }
 
 #[async_trait]
@@ -50,7 +51,7 @@ where
     T: serde::Serialize + serde::de::DeserializeOwned + Send + Sync + Unpin + 'static,
     U: MuxChannelSerde + Send,
 {
-    async fn get_channel(&mut self, id: &str) -> Result<Box<dyn Channel<T> + 'static>, MuxerError> {
+    async fn get_channel(&mut self, id: &str) -> Result<Box<dyn Duplex<T> + 'static>, MuxerError> {
         self.get_channel::<T>(id).await
     }
 }
@@ -66,7 +67,7 @@ pub mod mock {
         sync::{Arc, Mutex},
     };
 
-    use crate::duplex::DuplexChannel;
+    use crate::duplex::MpscDuplex;
 
     #[derive(Default)]
     struct FactoryState {
@@ -123,11 +124,11 @@ pub mod mock {
         async fn get_channel<T: Send + 'static>(
             &mut self,
             id: &str,
-        ) -> Result<Box<dyn Channel<T> + 'static>, MuxerError> {
+        ) -> Result<Box<dyn Duplex<T> + 'static>, MuxerError> {
             let mut state = self.state.lock().unwrap();
 
             if let Some(channel) = state.buffer.remove(id) {
-                if let Ok(channel) = channel.downcast::<DuplexChannel<T>>() {
+                if let Ok(channel) = channel.downcast::<MpscDuplex<T>>() {
                     Ok(channel)
                 } else {
                     Err(MuxerError::InternalError(
@@ -139,7 +140,7 @@ pub mod mock {
                     return Err(MuxerError::DuplicateStreamId(id.to_string()));
                 }
 
-                let (channel_0, channel_1) = DuplexChannel::new();
+                let (channel_0, channel_1) = MpscDuplex::new();
                 state.buffer.insert(id.to_string(), Box::new(channel_1));
 
                 Ok(Box::new(channel_0))

--- a/utils-aio/src/mux.rs
+++ b/utils-aio/src/mux.rs
@@ -67,7 +67,7 @@ pub mod mock {
         sync::{Arc, Mutex},
     };
 
-    use crate::duplex::MpscDuplex;
+    use crate::duplex::MemoryDuplex;
 
     #[derive(Default)]
     struct FactoryState {
@@ -128,7 +128,7 @@ pub mod mock {
             let mut state = self.state.lock().unwrap();
 
             if let Some(channel) = state.buffer.remove(id) {
-                if let Ok(channel) = channel.downcast::<MpscDuplex<T>>() {
+                if let Ok(channel) = channel.downcast::<MemoryDuplex<T>>() {
                     Ok(channel)
                 } else {
                     Err(MuxerError::InternalError(
@@ -140,7 +140,7 @@ pub mod mock {
                     return Err(MuxerError::DuplicateStreamId(id.to_string()));
                 }
 
-                let (channel_0, channel_1) = MpscDuplex::new();
+                let (channel_0, channel_1) = MemoryDuplex::new();
                 state.buffer.insert(id.to_string(), Box::new(channel_1));
 
                 Ok(Box::new(channel_0))

--- a/utils-aio/src/sink.rs
+++ b/utils-aio/src/sink.rs
@@ -1,0 +1,6 @@
+use futures::Sink;
+
+/// A sink with `std::io::Error` as the error type.
+pub trait IoSink<T>: Sink<T, Error = std::io::Error> {}
+
+impl<T, U> IoSink<T> for U where U: Sink<T, Error = std::io::Error> {}

--- a/utils-aio/src/stream.rs
+++ b/utils-aio/src/stream.rs
@@ -4,7 +4,12 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures::{future::FusedFuture, stream::FusedStream, Future, TryStream, TryStreamExt};
+use futures::{future::FusedFuture, stream::FusedStream, Future, Stream, TryStream, TryStreamExt};
+
+/// A stream which yields `std::io::Result<T>` items.
+pub trait IoStream<T>: Stream<Item = Result<T, std::io::Error>> {}
+
+impl<T, U> IoStream<U> for T where T: Stream<Item = Result<U, std::io::Error>> {}
 
 /// Future for the [`expect_next`](Duplex::expect_next) method.
 #[derive(Debug)]

--- a/utils-aio/src/stream.rs
+++ b/utils-aio/src/stream.rs
@@ -74,9 +74,9 @@ pub trait ExpectStreamExt: TryStream + Unpin {
     /// # futures::executor::block_on(async {
     /// use futures::{SinkExt, StreamExt};
     /// use utils_aio::stream::ExpectStreamExt;
-    /// use utils_aio::duplex::MpscDuplex;
+    /// use utils_aio::duplex::MemoryDuplex;
     ///
-    /// let (mut a, mut b) = MpscDuplex::new();
+    /// let (mut a, mut b) = MemoryDuplex::new();
     ///
     /// a.send(()).await.unwrap();
     /// a.close().await.unwrap();

--- a/utils-aio/src/stream.rs
+++ b/utils-aio/src/stream.rs
@@ -1,0 +1,91 @@
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::{future::FusedFuture, stream::FusedStream, Future, TryStream, TryStreamExt};
+
+/// Future for the [`expect_next`](Duplex::expect_next) method.
+#[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct ExpectNext<'a, St: ?Sized> {
+    stream: &'a mut St,
+}
+
+impl<St: ?Sized + Unpin> Unpin for ExpectNext<'_, St> {}
+
+impl<'a, St: ?Sized + TryStream + Unpin> ExpectNext<'a, St> {
+    pub(super) fn new(stream: &'a mut St) -> Self {
+        Self { stream }
+    }
+}
+
+impl<St: ?Sized + TryStream + Unpin + FusedStream> FusedFuture for ExpectNext<'_, St>
+where
+    <St as TryStream>::Error: Into<io::Error>,
+{
+    fn is_terminated(&self) -> bool {
+        self.stream.is_terminated()
+    }
+}
+
+impl<St: ?Sized + TryStream + Unpin> Future for ExpectNext<'_, St>
+where
+    <St as TryStream>::Error: Into<io::Error>,
+{
+    type Output = io::Result<St::Ok>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.stream
+            .try_poll_next_unpin(cx)
+            .map_err(|e| e.into())?
+            .map(|item| {
+                if let Some(item) = item {
+                    Ok(item)
+                } else {
+                    Err(io::ErrorKind::UnexpectedEof.into())
+                }
+            })
+    }
+}
+
+/// Extension trait for [`TryStream`](futures::stream::TryStream).
+pub trait ExpectStreamExt: TryStream + Unpin {
+    /// Creates a future that attempts to resolve the next item in the stream.
+    /// If an error is encountered before the next item, the error is returned
+    /// instead.
+    ///
+    /// Additionally, if the stream ends before the next item, an error is
+    /// returned.
+    ///
+    /// This is similar to the [`TryStreamExt::try_next`](futures::stream::TryStreamExt::try_next)
+    /// combinator, but returns an error if the stream ends before the next item instead of an
+    /// `Option`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # futures::executor::block_on(async {
+    /// use futures::{SinkExt, StreamExt};
+    /// use utils_aio::stream::ExpectStreamExt;
+    /// use utils_aio::duplex::MpscDuplex;
+    ///
+    /// let (mut a, mut b) = MpscDuplex::new();
+    ///
+    /// a.send(()).await.unwrap();
+    /// a.close().await.unwrap();
+    ///
+    /// assert!(b.expect_next().await.is_ok());
+    /// assert!(b.expect_next().await.is_err());
+    /// # })
+    /// ```
+    fn expect_next(&mut self) -> ExpectNext<'_, Self>
+    where
+        Self: Sized,
+    {
+        ExpectNext::new(self)
+    }
+}
+
+impl<T> ExpectStreamExt for T where T: TryStream + Unpin {}

--- a/utils/src/bits.rs
+++ b/utils/src/bits.rs
@@ -82,7 +82,11 @@ macro_rules! impl_from_bits {
 
                 for i in 0..<$typ>::BITS {
                     let Some(bit) = iter.next() else {
-                        panic!("Bit iterator yielded fewer bits than expected, got {}, expected {}", i, <$typ>::BITS);
+                        panic!(
+                            "Bit iterator yielded fewer bits than expected, got {}, expected {}",
+                            i,
+                            <$typ>::BITS
+                        );
                     };
 
                     value |= (bit as $typ) << i;
@@ -98,7 +102,11 @@ macro_rules! impl_from_bits {
 
                 for i in 0..<$typ>::BITS {
                     let Some(bit) = iter.next() else {
-                        panic!("Bit iterator yielded fewer bits than expected, got {}, expected {}", i, <$typ>::BITS);
+                        panic!(
+                            "Bit iterator yielded fewer bits than expected, got {}, expected {}",
+                            i,
+                            <$typ>::BITS
+                        );
                     };
 
                     value |= (bit as $typ) << ((<$typ>::BITS - 1) - i);


### PR DESCRIPTION
This PR improves our abstractions for IO channels.

# Changes
1. Introduce `IoStream` and `IoSink` traits which are simply super traits of their `futures::Stream` and `futures::Sink` counterparts with the error type set to `std::io::Error`. This is a matter of convenience for simplifying trait bounds.
2. Added `ExpectStreamExt` extension trait to obsolete the `expect_msg_or_err` macro with the `expect_next` method.
3. Rename `Channel` trait to `Duplex` and modify it to use the `IoStream` and `IoSink` traits. I think `Duplex` is a preferable name so that it is differentiated more from memory channels.
4. Rename `Duplex` to `MemoryDuplex`