### PR TITLE
refactor: replace Identity trait with Step

### DIFF
--- a/utils/src/range/mod.rs
+++ b/utils/src/range/mod.rs
@@ -429,7 +429,7 @@ pub trait Step: Sized {
     fn backward(start: Self, count: usize) -> Option<Self>;
 }
 
-macro_rules! impl_identity {
+macro_rules! impl_step {
     ($($ty:ty),+) => {
         $(
             impl Step for $ty {
@@ -445,7 +445,7 @@ macro_rules! impl_identity {
     };
 }
 
-impl_identity!(u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize);
+impl_step!(u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize);
 
 impl<T: Copy + Ord> RangeDisjoint<Range<T>> for Range<T> {
     fn is_disjoint(&self, other: &Range<T>) -> bool {

--- a/utils/src/range/mod.rs
+++ b/utils/src/range/mod.rs
@@ -422,10 +422,10 @@ pub trait RangeUnion<Rhs> {
 ///
 /// Similar to `std::iter::Step`, but not nightly-only.
 pub trait Step: Sized {
-    /// Step forwards by `count` elements.
+    /// Steps forwards by `count` elements.
     fn forward(start: Self, count: usize) -> Option<Self>;
 
-    /// Step backwards by `count` elements.
+    /// Steps backwards by `count` elements.
     fn backward(start: Self, count: usize) -> Option<Self>;
 }
 


### PR DESCRIPTION
This PR replaces the `Identity` trait with `Step` which is similar to the trait in `std` but works on stable.

Closes #18 