### PR TITLE
feat(spansy): HTTP body content + parsing

### DIFF
--- a/spansy/src/http/mod.rs
+++ b/spansy/src/http/mod.rs
@@ -7,8 +7,8 @@ use bytes::Bytes;
 
 pub use span::{parse_request, parse_response};
 pub use types::{
-    Body, Code, Header, HeaderName, HeaderValue, Method, Reason, Request, RequestLine, Response,
-    Status, Target,
+    Body, BodyContent, Code, Header, HeaderName, HeaderValue, Method, Reason, Request, RequestLine,
+    Response, Status, Target,
 };
 
 use crate::ParseError;

--- a/spansy/src/http/span.rs
+++ b/spansy/src/http/span.rs
@@ -281,12 +281,12 @@ fn response_body_len(response: &Response) -> Result<usize, ParseError> {
     }
 }
 
-/// Parses a request or response body.
+/// Parses a request or response message body.
 ///
 /// # Arguments
 ///
 /// * `src` - The source bytes.
-/// * `range` - The range of the body in the source bytes.
+/// * `range` - The range of the message body in the source bytes.
 /// * `content_type` - The value of the Content-Type header.
 fn parse_body(src: &Bytes, range: Range<usize>, content_type: &[u8]) -> Result<Body, ParseError> {
     let span = Span::new_bytes(src.clone(), range.clone());

--- a/spansy/src/http/span.rs
+++ b/spansy/src/http/span.rs
@@ -1,12 +1,14 @@
+use std::ops::Range;
+
 use bytes::Bytes;
 
 use crate::{
     helpers::get_span_range,
     http::{
-        Body, Code, Header, HeaderName, HeaderValue, Method, Reason, Request, RequestLine,
-        Response, Status, Target,
+        Body, BodyContent, Code, Header, HeaderName, HeaderValue, Method, Reason, Request,
+        RequestLine, Response, Status, Target,
     },
-    ParseError, Span,
+    json, ParseError, Span,
 };
 
 const MAX_HEADERS: usize = 128;
@@ -87,11 +89,14 @@ pub(crate) fn parse_request_from_bytes(src: &Bytes, offset: usize) -> Result<Req
             )));
         }
 
-        request.span = Span::new_bytes(src.clone(), offset..range.end);
+        let content_type = request
+            .headers_with_name("Content-Type")
+            .next()
+            .map(|header| header.value.as_bytes())
+            .unwrap_or_default();
 
-        request.body = Some(Body {
-            span: Span::new_bytes(src.clone(), range),
-        });
+        request.body = Some(parse_body(src, range.clone(), content_type)?);
+        request.span = Span::new_bytes(src.clone(), offset..range.end);
     }
 
     Ok(request)
@@ -175,11 +180,14 @@ pub(crate) fn parse_response_from_bytes(
             )));
         }
 
-        response.span = Span::new_bytes(src.clone(), offset..range.end);
+        let content_type = response
+            .headers_with_name("Content-Type")
+            .next()
+            .map(|header| header.value.as_bytes())
+            .unwrap_or_default();
 
-        response.body = Some(Body {
-            span: Span::new_bytes(src.clone(), range),
-        });
+        response.body = Some(parse_body(src, range.clone(), content_type)?);
+        response.span = Span::new_bytes(src.clone(), offset..range.end);
     }
 
     Ok(response)
@@ -273,6 +281,27 @@ fn response_body_len(response: &Response) -> Result<usize, ParseError> {
     }
 }
 
+/// Parses a request or response body.
+///
+/// # Arguments
+///
+/// * `src` - The source bytes.
+/// * `range` - The range of the body in the source bytes.
+/// * `content_type` - The value of the Content-Type header.
+fn parse_body(src: &Bytes, range: Range<usize>, content_type: &[u8]) -> Result<Body, ParseError> {
+    let span = Span::new_bytes(src.clone(), range.clone());
+    let content = if content_type.get(..16) == Some(b"application/json".as_slice()) {
+        let mut value = json::parse(span.data.clone())?;
+        value.offset(range.start);
+
+        BodyContent::Json(value)
+    } else {
+        BodyContent::Unknown(span.clone())
+    };
+
+    Ok(Body { span, content })
+}
+
 #[cfg(test)]
 mod tests {
     use crate::Spanned;
@@ -320,6 +349,19 @@ mod tests {
                         Content-Type: text/plain\r\n\
                         Connection: keep-alive\r\n\r\n\
                         pong";
+
+    const TEST_REQUEST_JSON: &[u8] = b"\
+                        POST / HTTP/1.1\r\n\
+                        Host: localhost\r\n\
+                        Content-Type: application/json\r\n\
+                        Content-Length: 14\r\n\r\n\
+                        {\"foo\": \"bar\"}";
+
+    const TEST_RESPONSE_JSON: &[u8] = b"\
+                        HTTP/1.1 200 OK\r\n\
+                        Content-Type: application/json\r\n\
+                        Content-Length: 14\r\n\r\n\
+                        {\"foo\": \"bar\"}";
 
     #[test]
     fn test_parse_request() {
@@ -431,5 +473,27 @@ mod tests {
             res.body.unwrap().span(),
             b"<html>\n<body>\n<h1>Hello, World!</h1>\n</body>\n</html>".as_slice()
         );
+    }
+
+    #[test]
+    fn test_parse_request_json() {
+        let req = parse_request(TEST_REQUEST_JSON).unwrap();
+
+        let BodyContent::Json(value) = req.body.unwrap().content else {
+            panic!("body is not json");
+        };
+
+        assert_eq!(value.span(), "{\"foo\": \"bar\"}");
+    }
+
+    #[test]
+    fn test_parse_response_json() {
+        let res = parse_response(TEST_RESPONSE_JSON).unwrap();
+
+        let BodyContent::Json(value) = res.body.unwrap().content else {
+            panic!("body is not json");
+        };
+
+        assert_eq!(value.span(), "{\"foo\": \"bar\"}");
     }
 }

--- a/spansy/src/http/types.rs
+++ b/spansy/src/http/types.rs
@@ -370,7 +370,7 @@ impl Spanned for Body {
     }
 }
 
-/// An HTTP request or response body content.
+/// An HTTP request or response payload body content.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]

--- a/spansy/src/http/types.rs
+++ b/spansy/src/http/types.rs
@@ -1,6 +1,6 @@
 use utils::range::{RangeDifference, RangeSet};
 
-use crate::{Span, Spanned};
+use crate::{json::JsonValue, Span, Spanned};
 
 /// An HTTP header name.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -347,6 +347,9 @@ impl Spanned for Response {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Body {
     pub(crate) span: Span,
+
+    /// The body content.
+    pub content: BodyContent,
 }
 
 impl Body {
@@ -364,5 +367,24 @@ impl Body {
 impl Spanned for Body {
     fn span(&self) -> &Span {
         &self.span
+    }
+}
+
+/// An HTTP request or response body content.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum BodyContent {
+    /// Body with an `application/json` content type.
+    Json(JsonValue),
+    /// Body with an unknown content type.
+    Unknown(Span),
+}
+
+impl Spanned for BodyContent {
+    fn span(&self) -> &Span {
+        match self {
+            BodyContent::Json(json) => json.span().as_ref(),
+            BodyContent::Unknown(span) => span,
+        }
     }
 }

--- a/spansy/src/http/types.rs
+++ b/spansy/src/http/types.rs
@@ -342,7 +342,7 @@ impl Spanned for Response {
     }
 }
 
-/// An HTTP request or response body.
+/// An HTTP request or response payload body.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Body {

--- a/spansy/src/http/types.rs
+++ b/spansy/src/http/types.rs
@@ -373,6 +373,7 @@ impl Spanned for Body {
 /// An HTTP request or response body content.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
 pub enum BodyContent {
     /// Body with an `application/json` content type.
     Json(JsonValue),

--- a/spansy/src/lib.rs
+++ b/spansy/src/lib.rs
@@ -169,6 +169,16 @@ impl Span<str> {
     }
 }
 
+impl AsRef<Span<[u8]>> for Span<str> {
+    fn as_ref(&self) -> &Span<[u8]> {
+        // # Safety
+        // Span<str> can be safely converted to Span<[u8]> because they have
+        // an identical layout and only differ in the phantom type parameter
+        // which is a ZST.
+        unsafe { &*(self as *const Span<str> as *const Span<[u8]>) }
+    }
+}
+
 impl AsRef<str> for Span<str> {
     fn as_ref(&self) -> &str {
         // # Safety


### PR DESCRIPTION
This PR adds a `BodyContent` type in the http module, and now attempts to parse the body content if it is recognized. This does not yet support the chunked transfer encoding, that'll come later.