### PR TITLE
docs: add style guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,3 +34,35 @@ depending on the types of changes defined by
 - `Security` in case of vulnerabilities.
 
 If the required subsection does not exist yet under **Unreleased**, create it!
+
+## Style
+
+### Capitalization and punctuation
+
+Both line comments and doc comments must be capitalized. Each sentence must end with a period.
+
+```
+// This is a line comment.
+```
+
+### Avoid overly long comment lines
+
+We recommend a soft comment line length limit of **100 characters**. Authors should aim to wrap lines before hitting this limit, but it is not a hard limit. Comments are allowed to exceed this limit.
+
+### Verbs in function description
+
+Comments describing a function usually start with a verb. That verb must use the third-person present tense, e.g. "Creates", "Sets", "Computes".
+
+### Function arguments
+
+Comments for function arguments must adhere to this pattern:
+
+```
+/// Performs a certain computation. Any other description of the function.
+///
+/// # Arguments
+///
+/// * `arg1` - The first argument.
+/// * `arg2` - The second argument.
+pub fn compute(...
+```


### PR DESCRIPTION
This PR copies the style guide from https://github.com/tlsnotary/tlsn/blob/dev/CONTRIBUTING.md