### PR TITLE
feat(uid-mux): TestFramedMux

### DIFF
--- a/serio/src/channel.rs
+++ b/serio/src/channel.rs
@@ -16,6 +16,7 @@ use crate::{Deserialize, Serialize, Sink, Stream};
 type Item = Box<dyn Any + Send + Sync + 'static>;
 
 /// A memory sink that can be used to send any serializable type to the receiver.
+#[derive(Debug)]
 pub struct MemorySink(mpsc::Sender<Item>);
 
 impl Sink for MemorySink {
@@ -50,6 +51,7 @@ impl Sink for MemorySink {
 }
 
 /// A memory stream that can be used to receive any deserializable type from the sender.
+#[derive(Debug)]
 pub struct MemoryStream(mpsc::Receiver<Item>);
 
 impl Stream for MemoryStream {
@@ -76,6 +78,7 @@ pub fn channel(buffer: usize) -> (MemorySink, MemoryStream) {
 }
 
 /// A memory duplex that can be used to send and receive any serializable types.
+#[derive(Debug)]
 pub struct MemoryDuplex {
     sink: MemorySink,
     stream: MemoryStream,

--- a/uid-mux/src/test_utils.rs
+++ b/uid-mux/src/test_utils.rs
@@ -45,3 +45,147 @@ pub fn test_yamux_pair_framed<C: Clone>(
 
     ((ctrl_a, a), (ctrl_b, b))
 }
+
+#[cfg(feature = "serio")]
+mod serio {
+    use core::fmt;
+    use std::{
+        collections::{HashMap, HashSet},
+        sync::{Arc, Mutex},
+    };
+
+    use async_trait::async_trait;
+    use serio::channel::{duplex, MemoryDuplex};
+
+    use crate::serio::FramedUidMux;
+
+    /// Error for [`TestFramedMux`].
+    #[derive(Debug)]
+    pub struct TestFramedMuxError(&'static str);
+
+    impl fmt::Display for TestFramedMuxError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+
+    impl std::error::Error for TestFramedMuxError {}
+
+    #[derive(Debug, Default)]
+    struct State {
+        exists: HashSet<Vec<u8>>,
+        waiting_a: HashMap<Vec<u8>, MemoryDuplex>,
+        waiting_b: HashMap<Vec<u8>, MemoryDuplex>,
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum Role {
+        A,
+        B,
+    }
+
+    /// A test framed mux.
+    #[derive(Debug, Clone)]
+    pub struct TestFramedMux {
+        role: Role,
+        buffer: usize,
+        state: Arc<Mutex<State>>,
+    }
+
+    #[async_trait]
+    impl<Id: AsRef<[u8]> + Send + Sync> FramedUidMux<Id> for TestFramedMux {
+        /// Stream type.
+        type Framed = MemoryDuplex;
+        /// Error type.
+        type Error = TestFramedMuxError;
+
+        /// Opens a new framed stream with the given id.
+        async fn open_framed(&self, id: &Id) -> Result<Self::Framed, Self::Error> {
+            let mut state = self.state.lock().unwrap();
+
+            if let Some(channel) = match self.role {
+                Role::A => state.waiting_a.remove(id.as_ref()),
+                Role::B => state.waiting_b.remove(id.as_ref()),
+            } {
+                Ok(channel)
+            } else {
+                if !state.exists.insert(id.as_ref().to_vec()) {
+                    return Err(TestFramedMuxError("duplicate stream id"));
+                }
+
+                let (a, b) = duplex(self.buffer);
+
+                match self.role {
+                    Role::A => {
+                        state.waiting_b.insert(id.as_ref().to_vec(), b);
+                        Ok(a)
+                    }
+                    Role::B => {
+                        state.waiting_a.insert(id.as_ref().to_vec(), a);
+                        Ok(b)
+                    }
+                }
+            }
+        }
+    }
+
+    /// Creates a test pair of framed mux instances.
+    pub fn test_framed_mux(buffer: usize) -> (TestFramedMux, TestFramedMux) {
+        let state = Arc::new(Mutex::new(State::default()));
+
+        (
+            TestFramedMux {
+                role: Role::A,
+                buffer,
+                state: state.clone(),
+            },
+            TestFramedMux {
+                role: Role::B,
+                buffer,
+                state,
+            },
+        )
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use serio::{SinkExt, StreamExt};
+
+        use super::*;
+
+        #[test]
+        fn test_framed_mux() {
+            let (a, b) = super::test_framed_mux(1);
+
+            futures::executor::block_on(async {
+                let mut a_0 = a.open_framed(&[0]).await.unwrap();
+                let mut b_0 = b.open_framed(&[0]).await.unwrap();
+
+                let mut a_1 = a.open_framed(&[1]).await.unwrap();
+                let mut b_1 = b.open_framed(&[1]).await.unwrap();
+
+                a_0.send(42u8).await.unwrap();
+                assert_eq!(b_0.next::<u8>().await.unwrap().unwrap(), 42);
+
+                a_1.send(69u8).await.unwrap();
+                assert_eq!(b_1.next::<u8>().await.unwrap().unwrap(), 69u8);
+            })
+        }
+
+        #[test]
+        fn test_framed_mux_duplicate() {
+            let (a, b) = super::test_framed_mux(1);
+
+            futures::executor::block_on(async {
+                let _ = a.open_framed(&[0]).await.unwrap();
+                let _ = b.open_framed(&[0]).await.unwrap();
+
+                assert!(a.open_framed(&[0]).await.is_err());
+                assert!(b.open_framed(&[0]).await.is_err());
+            })
+        }
+    }
+}
+
+#[cfg(feature = "serio")]
+pub use serio::*;


### PR DESCRIPTION
This PR adds a framed mux utility which uses memory channels instead of serializing.