### PR TITLE
spansy: support Transfer-Encoding

### DIFF
--- a/spansy/Cargo.toml
+++ b/spansy/Cargo.toml
@@ -20,3 +20,4 @@ thiserror.workspace = true
 httparse = "1.8"
 pest = { version = "2.7" }
 pest_derive = { version = "2.7" }
+flate2 = "1.0.30"

--- a/spansy/src/http/mod.rs
+++ b/spansy/src/http/mod.rs
@@ -2,6 +2,7 @@
 
 mod span;
 mod types;
+mod parse;
 
 use bytes::Bytes;
 

--- a/spansy/src/http/mod.rs
+++ b/spansy/src/http/mod.rs
@@ -11,6 +11,7 @@ pub use types::{
     Body, BodyContent, Code, Header, HeaderName, HeaderValue, Method, Reason, Request, RequestLine,
     Response, Status, Target,
 };
+pub use parse::{parse_chunked_body, parse_deflate_body, parse_gzip_body, parse_identity_body};
 
 use crate::ParseError;
 

--- a/spansy/src/http/parse.rs
+++ b/spansy/src/http/parse.rs
@@ -1,0 +1,10 @@
+// Imports
+
+// Parsing functions for Transfer-Encoding header types
+fn parse_chunked_body() {}
+
+fn parse_gzip_body() {}
+
+fn parse_deflate_body() {}
+
+fn parse_idenity_body() {}

--- a/spansy/src/http/parse.rs
+++ b/spansy/src/http/parse.rs
@@ -10,39 +10,32 @@ pub fn parse_chunked_body(src: &Bytes, offset: usize) -> Result<(Bytes, usize), 
     let mut pos = offset;
 
     loop {
-        // Find the end of the chunk size line
         let chunk_size_end = src[pos..]
             .windows(2)
             .position(|w| w == b"\r\n")
             .ok_or_else(|| ParseError("Invalid chunked encoding: missing chunk size CRLF".to_string()))?
             + pos;
         
-        // Parse the chunk size
         let chunk_size_str = std::str::from_utf8(&src[pos..chunk_size_end])
             .map_err(|_| ParseError("Invalid chunk size encoding".to_string()))?;
         let chunk_size = usize::from_str_radix(chunk_size_str.trim(), 16)
             .map_err(|_| ParseError("Invalid chunk size value".to_string()))?;
         
-        // Move past the chunk size line
         pos = chunk_size_end + 2;
         
-        // If chunk size is zero, this is the last chunk
         if chunk_size == 0 {
             break;
         }
         
-        // Extract the chunk data
         let chunk_data_end = pos + chunk_size;
         if chunk_data_end > src.len() {
             return Err(ParseError("Chunk data exceeds source length".to_string()));
         }
         body.extend_from_slice(&src[pos..chunk_data_end]);
         
-        // Move past the chunk data and the trailing CRLF
         pos = chunk_data_end + 2;
     }
     
-    // Move past the final CRLF after the last chunk
     pos += 2;
     
     Ok((body.freeze(), pos))

--- a/spansy/src/http/parse.rs
+++ b/spansy/src/http/parse.rs
@@ -55,6 +55,11 @@ fn parse_gzip_body(src: &Bytes) -> Result<Bytes, ParseError> {
     Ok(Bytes::from(decompressed))
 }
 
-fn parse_deflate_body() {}
+fn parse_deflate_body(src: &Bytes) -> Result<Bytes, ParseError> {
+    let mut decoder = DeflateDecoder::new(&src[..]);
+    let mut decompressed = Vec::new();
+    decoder.read_to_end(&mut decompressed).map_err(|e| ParseError(format!("Failed to decompress deflate body: {}", e)))?;
+    Ok(Bytes::from(decompressed))
+}
 
 fn parse_idenity_body() {}

--- a/spansy/src/http/parse.rs
+++ b/spansy/src/http/parse.rs
@@ -1,7 +1,50 @@
-// Imports
+use crate::ParseError;
+use bytes::{Bytes, BytesMut};
 
 // Parsing functions for Transfer-Encoding header types
-fn parse_chunked_body() {}
+// Parse Transfer-Encoding: chunked body
+fn parse_chunked_body(src: &Bytes, offset: usize) -> Result<(Bytes, usize), ParseError> {
+    let mut body = BytesMut::new();
+    let mut pos = offset;
+
+    loop {
+        // Find the end of the chunk size line
+        let chunk_size_end = src[pos..]
+            .windows(2)
+            .position(|w| w == b"\r\n")
+            .ok_or_else(|| ParseError("Invalid chunked encoding: missing chunk size CRLF".to_string()))?
+            + pos;
+        
+        // Parse the chunk size
+        let chunk_size_str = std::str::from_utf8(&src[pos..chunk_size_end])
+            .map_err(|_| ParseError("Invalid chunk size encoding".to_string()))?;
+        let chunk_size = usize::from_str_radix(chunk_size_str.trim(), 16)
+            .map_err(|_| ParseError("Invalid chunk size value".to_string()))?;
+        
+        // Move past the chunk size line
+        pos = chunk_size_end + 2;
+        
+        // If chunk size is zero, this is the last chunk
+        if chunk_size == 0 {
+            break;
+        }
+        
+        // Extract the chunk data
+        let chunk_data_end = pos + chunk_size;
+        if chunk_data_end > src.len() {
+            return Err(ParseError("Chunk data exceeds source length".to_string()));
+        }
+        body.extend_from_slice(&src[pos..chunk_data_end]);
+        
+        // Move past the chunk data and the trailing CRLF
+        pos = chunk_data_end + 2;
+    }
+    
+    // Move past the final CRLF after the last chunk
+    pos += 2;
+    
+    Ok((body.freeze(), pos))
+}
 
 fn parse_gzip_body() {}
 

--- a/spansy/src/http/parse.rs
+++ b/spansy/src/http/parse.rs
@@ -1,5 +1,7 @@
 use crate::ParseError;
 use bytes::{Bytes, BytesMut};
+use flate2::read::{GzDecoder, DeflateDecoder};
+use std::io::Read;
 
 // Parsing functions for Transfer-Encoding header types
 // Parse Transfer-Encoding: chunked body
@@ -46,7 +48,12 @@ fn parse_chunked_body(src: &Bytes, offset: usize) -> Result<(Bytes, usize), Pars
     Ok((body.freeze(), pos))
 }
 
-fn parse_gzip_body() {}
+fn parse_gzip_body(src: &Bytes) -> Result<Bytes, ParseError> {
+    let mut decoder = GzDecoder::new(&src[..]);
+    let mut decompressed = Vec::new();
+    decoder.read_to_end(&mut decompressed).map_err(|e| ParseError(format!("Failed to decompress gzip body: {}", e)))?;
+    Ok(Bytes::from(decompressed))
+}
 
 fn parse_deflate_body() {}
 

--- a/spansy/src/http/parse.rs
+++ b/spansy/src/http/parse.rs
@@ -62,4 +62,6 @@ fn parse_deflate_body(src: &Bytes) -> Result<Bytes, ParseError> {
     Ok(Bytes::from(decompressed))
 }
 
-fn parse_idenity_body() {}
+fn parse_identity_body(src: &Bytes) -> Result<Bytes, ParseError> {
+    Ok(src.clone())
+}

--- a/spansy/src/http/parse.rs
+++ b/spansy/src/http/parse.rs
@@ -4,8 +4,8 @@ use flate2::read::{GzDecoder, DeflateDecoder};
 use std::io::Read;
 
 // Parsing functions for Transfer-Encoding header types
-// Parse Transfer-Encoding: chunked body
-fn parse_chunked_body(src: &Bytes, offset: usize) -> Result<(Bytes, usize), ParseError> {
+/// Parse Transfer-Encoding: chunked body
+pub fn parse_chunked_body(src: &Bytes, offset: usize) -> Result<(Bytes, usize), ParseError> {
     let mut body = BytesMut::new();
     let mut pos = offset;
 
@@ -48,20 +48,23 @@ fn parse_chunked_body(src: &Bytes, offset: usize) -> Result<(Bytes, usize), Pars
     Ok((body.freeze(), pos))
 }
 
-fn parse_gzip_body(src: &Bytes) -> Result<Bytes, ParseError> {
+/// Parse Transfer-Encoding: gzip body
+pub fn parse_gzip_body(src: &Bytes) -> Result<Bytes, ParseError> {
     let mut decoder = GzDecoder::new(&src[..]);
     let mut decompressed = Vec::new();
     decoder.read_to_end(&mut decompressed).map_err(|e| ParseError(format!("Failed to decompress gzip body: {}", e)))?;
     Ok(Bytes::from(decompressed))
 }
 
-fn parse_deflate_body(src: &Bytes) -> Result<Bytes, ParseError> {
+/// Parse Transfer-Encoding: deflate body
+pub fn parse_deflate_body(src: &Bytes) -> Result<Bytes, ParseError> {
     let mut decoder = DeflateDecoder::new(&src[..]);
     let mut decompressed = Vec::new();
     decoder.read_to_end(&mut decompressed).map_err(|e| ParseError(format!("Failed to decompress deflate body: {}", e)))?;
     Ok(Bytes::from(decompressed))
 }
 
-fn parse_identity_body(src: &Bytes) -> Result<Bytes, ParseError> {
+/// Parse Transfer-Encoding: identity body
+pub fn parse_identity_body(src: &Bytes) -> Result<Bytes, ParseError> {
     Ok(src.clone())
 }

--- a/spansy/src/http/span.rs
+++ b/spansy/src/http/span.rs
@@ -168,7 +168,23 @@ pub(crate) fn parse_response_from_bytes(
 
     let body_len = response_body_len(&response)?;
 
-    if body_len > 0 {
+    if body_len == usize::MAX {
+        // Handle different transfer encodings
+        let transfer_encoding = response.headers_with_name("Transfer-Encoding").next().unwrap().value.as_bytes();
+        let (body_bytes, end_pos) = match transfer_encoding {
+            b"chunked" => parse_chunked_body(src, head_end)?,
+            b"gzip" => (parse_gzip_body(&src.slice(head_end..))?, src.len()),
+            b"deflate" => (parse_deflate_body(&src.slice(head_end..))?, src.len()),
+            b"identity" => (parse_identity_body(&src.slice(head_end..))?, src.len()),
+            _ => return Err(ParseError("Unsupported Transfer-Encoding".to_string())),
+        };
+        let body_span = Span::new_bytes(body_bytes.clone(), 0..body_bytes.len());
+        response.body = Some(Body {
+            span: Span::new_bytes(src.clone(), head_end..end_pos),
+            content: BodyContent::Unknown(body_span),
+        });
+        response.span = Span::new_bytes(src.clone(), offset..end_pos);
+    } else if body_len > 0 {
         let range = head_end..head_end + body_len;
 
         if range.end > src.len() {

--- a/spansy/src/http/span.rs
+++ b/spansy/src/http/span.rs
@@ -6,7 +6,7 @@ use crate::{
     helpers::get_span_range,
     http::{
         Body, BodyContent, Code, Header, HeaderName, HeaderValue, Method, Reason, Request,
-        RequestLine, Response, Status, Target,
+        RequestLine, Response, Status, Target, parse_chunked_body, parse_deflate_body, parse_gzip_body, parse_identity_body
     },
     json, ParseError, Span,
 };


### PR DESCRIPTION
Fixes #34 

In order to support HTTP Transfer Encoding, when these headers are detected, we assign the `transfer_encoding` value to `usize::MAX` to flag that the response must be parsed for Transfer Encoding formats.

After some review, we believe it's best not to use `usize::MAX`. [from @sinui0]: We need to modify the Body type and add the types to represent a chunked body. Also the spans in the content type, eg application/json, need to account for the chunking boundaries

Work in progress; todo:
- correct implementation approach
- unit tests
- integration tests