### PR TITLE
Improve handling of Transfer-Encoding errors

### DIFF
--- a/spansy/CHANGELOG.md
+++ b/spansy/CHANGELOG.md
@@ -5,3 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+- Improve handling of Transfer-Encoding errors

--- a/spansy/src/http/span.rs
+++ b/spansy/src/http/span.rs
@@ -270,22 +270,23 @@ fn response_body_len(response: &Response) -> Result<usize, ParseError> {
 
     if response
         .headers_with_name("Transfer-Encoding")
-        .any(|h| {
+        .next()
+        .map(|h| {
             std::str::from_utf8(h.value.0.as_bytes())
                 .unwrap_or("")
                 .split(',')
                 .any(|v| v.trim() != "identity")
         })
+        .unwrap_or(false)
     {
         let bad_values = response
             .headers_with_name("Transfer-Encoding")
-            .map(|h| std::str::from_utf8(h.value.0.as_bytes()).unwrap_or(""))
+            .map(|h| std::str::from_utf8(h.value.0.as_bytes()).unwrap_or("{invalid utf-8}"))
             .collect::<Vec<_>>()
             .join(", ");
 
         Err(ParseError(format!(
-            "Transfer-Encoding other than identity not supported yet: {:?}",
-            bad_values
+            "Transfer-Encoding other than identity not supported yet: {bad_values}"
         )))
     } else if let Some(h) = response.headers_with_name("Content-Length").next() {
         // If a valid Content-Length header field is present without Transfer-Encoding, its decimal value

--- a/spansy/src/http/span.rs
+++ b/spansy/src/http/span.rs
@@ -218,8 +218,8 @@ fn request_body_len(request: &Request) -> Result<usize, ParseError> {
     // The presence of a message body in a request is signaled by a Content-Length
     // or Transfer-Encoding header field.
 
-    // If a message is received with both a Transfer-Encoding and a Content-Length header field,
-    // the Transfer-Encoding overrides the Content-Length
+    // If a message is received with both a Transfer-Encoding and a Content-Length
+    // header field, the Transfer-Encoding overrides the Content-Length
     if request
         .headers_with_name("Transfer-Encoding")
         .next()
@@ -241,22 +241,25 @@ fn request_body_len(request: &Request) -> Result<usize, ParseError> {
             "Transfer-Encoding other than identity not supported yet: {bad_values}"
         )))
     } else if let Some(h) = request.headers_with_name("Content-Length").next() {
-        // If a valid Content-Length header field is present without Transfer-Encoding, its decimal value
-        // defines the expected message body length in octets.
+        // If a valid Content-Length header field is present without Transfer-Encoding,
+        // its decimal value defines the expected message body length in octets.
         std::str::from_utf8(h.value.0.as_bytes())?
             .parse::<usize>()
             .map_err(|err| ParseError(format!("failed to parse Content-Length value: {err}")))
     } else {
-        // If this is a request message and none of the above are true, then the message body length is zero
+        // If this is a request message and none of the above are true, then the message
+        // body length is zero
         Ok(0)
     }
 }
 
 /// Calculates the length of the response body according to RFC 9112, section 6.
 fn response_body_len(response: &Response) -> Result<usize, ParseError> {
-    // Any response to a HEAD request and any response with a 1xx (Informational), 204 (No Content), or 304 (Not Modified)
-    // status code is always terminated by the first empty line after the header fields, regardless of the header fields
-    // present in the message, and thus cannot contain a message body or trailer section.
+    // Any response to a HEAD request and any response with a 1xx (Informational),
+    // 204 (No Content), or 304 (Not Modified) status code is always terminated
+    // by the first empty line after the header fields, regardless of the header
+    // fields present in the message, and thus cannot contain a message body or
+    // trailer section.
     match response
         .status
         .code
@@ -289,16 +292,18 @@ fn response_body_len(response: &Response) -> Result<usize, ParseError> {
             "Transfer-Encoding other than identity not supported yet: {bad_values}"
         )))
     } else if let Some(h) = response.headers_with_name("Content-Length").next() {
-        // If a valid Content-Length header field is present without Transfer-Encoding, its decimal value
-        // defines the expected message body length in octets.
+        // If a valid Content-Length header field is present without Transfer-Encoding,
+        // its decimal value defines the expected message body length in octets.
         std::str::from_utf8(h.value.0.as_bytes())?
             .parse::<usize>()
             .map_err(|err| ParseError(format!("failed to parse Content-Length value: {err}")))
     } else {
-        // If this is a response message and none of the above are true, then there is no way to
-        // determine the length of the message body except by reading it until the connection is closed.
+        // If this is a response message and none of the above are true, then there is
+        // no way to determine the length of the message body except by reading
+        // it until the connection is closed.
 
-        // We currently consider this an error because we have no outer context information.
+        // We currently consider this an error because we have no outer context
+        // information.
         Err(ParseError(
             "A response with a body must contain either a Content-Length or Transfer-Encoding header".to_string(),
         ))
@@ -577,27 +582,35 @@ mod tests {
     fn test_parse_request_transfer_encoding_chunked() {
         let err = parse_request(TEST_REQUEST_TRANSFER_ENCODING_CHUNKED).unwrap_err();
         assert!(matches!(err, ParseError(_)));
-        assert!(err.to_string().contains("Transfer-Encoding other than identity not supported yet"));
+        assert!(err
+            .to_string()
+            .contains("Transfer-Encoding other than identity not supported yet"));
     }
 
     #[test]
     fn test_parse_response_transfer_encoding_chunked() {
         let err = parse_response(TEST_RESPONSE_TRANSFER_ENCODING_CHUNKED).unwrap_err();
         assert!(matches!(err, ParseError(_)));
-        assert!(err.to_string().contains("Transfer-Encoding other than identity not supported yet"));
+        assert!(err
+            .to_string()
+            .contains("Transfer-Encoding other than identity not supported yet"));
     }
 
     #[test]
     fn test_parse_request_transfer_encoding_multiple() {
         let err = parse_request(TEST_REQUEST_TRANSFER_ENCODING_MULTIPLE).unwrap_err();
         assert!(matches!(err, ParseError(_)));
-        assert!(err.to_string().contains("Transfer-Encoding other than identity not supported yet"));
+        assert!(err
+            .to_string()
+            .contains("Transfer-Encoding other than identity not supported yet"));
     }
 
     #[test]
     fn test_parse_response_transfer_encoding_multiple() {
         let err = parse_response(TEST_RESPONSE_TRANSFER_ENCODING_MULTIPLE).unwrap_err();
         assert!(matches!(err, ParseError(_)));
-        assert!(err.to_string().contains("Transfer-Encoding other than identity not supported yet"));
+        assert!(err
+            .to_string()
+            .contains("Transfer-Encoding other than identity not supported yet"));
     }
 }

--- a/spansy/src/http/span.rs
+++ b/spansy/src/http/span.rs
@@ -222,22 +222,23 @@ fn request_body_len(request: &Request) -> Result<usize, ParseError> {
     // the Transfer-Encoding overrides the Content-Length
     if request
         .headers_with_name("Transfer-Encoding")
-        .any(|h| {
+        .next()
+        .map(|h| {
             std::str::from_utf8(h.value.0.as_bytes())
                 .unwrap_or("")
                 .split(',')
                 .any(|v| v.trim() != "identity")
         })
+        .unwrap_or(false)
     {
         let bad_values = request
             .headers_with_name("Transfer-Encoding")
-            .map(|h| std::str::from_utf8(h.value.0.as_bytes()).unwrap_or(""))
+            .map(|h| std::str::from_utf8(h.value.0.as_bytes()).unwrap_or("{invalid utf-8}"))
             .collect::<Vec<_>>()
             .join(", ");
 
         Err(ParseError(format!(
-            "Transfer-Encoding other than identity not supported yet: {:?}",
-            bad_values
+            "Transfer-Encoding other than identity not supported yet: {bad_values}"
         )))
     } else if let Some(h) = request.headers_with_name("Content-Length").next() {
         // If a valid Content-Length header field is present without Transfer-Encoding, its decimal value


### PR DESCRIPTION
Transfer-Encoding errors are currently very opaque. This change updates the logic to allow for `Transfer-Encoding: identity` (the effective default), and add the incorrect values to the error message to make it easier to troubleshoot bad Transfer-Encoding values.

An example of the new error message:

`parsing error: Transfer-Encoding other than identity not supported yet: "chunked"`