### PR TITLE
Simplified Transfer-Encoding Error Handling

### DIFF
--- a/spansy/CHANGELOG.md
+++ b/spansy/CHANGELOG.md
@@ -5,3 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+- Improve handling of Transfer-Encoding errors


### PR DESCRIPTION
Extending PR #46 by @TheFrozenFire with some helper functions to simplify the handling of Transfer-Encoding errors.
Includes updates re comments by @sinui0 on #46.