### PR TITLE
perf(utils): further optimise subset check.

### DIFF
--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -14,6 +14,12 @@ name = "utils"
 serde = { workspace = true, optional = true, features = ["derive"] }
 
 [dev-dependencies]
+criterion = { version = "0.5" }
 rstest = "0.12"
 rand = { workspace = true }
 itertools = "0.11.0"
+
+
+[[bench]]
+name = "range"
+harness = false

--- a/utils/benches/range.rs
+++ b/utils/benches/range.rs
@@ -1,0 +1,41 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use utils::range::{RangeSet, Subset};
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let mut rangeset_vec = Vec::new();
+    for i in 0..10000 {
+        if i % 2 == 0 {
+            // [0..1, 2..3, ... , 9998..9999].
+            rangeset_vec.push(i..i + 1);
+        }
+    }
+    let rangeset = RangeSet::from(rangeset_vec);
+
+    c.bench_function("boundary_range_subset_of_rangeset", |b| {
+        b.iter(|| boundary_range_subset_of_rangeset(black_box(&rangeset)))
+    });
+
+    c.bench_function("rangeset_subset_of_boundary_rangeset", |b| {
+        b.iter(|| rangeset_subset_of_boundary_rangeset(black_box(&rangeset)))
+    });
+}
+
+// To benchmark the worst case where [range.start] is close to [other.end()], i.e. N
+// iterations are needed if there is no boundary short citcuit (N == other.len_ranges()).
+fn boundary_range_subset_of_rangeset(other: &RangeSet<u32>) {
+    let range = 9997..10005;
+    let _ = range.is_subset(other);
+}
+
+// To benchmark the worst case where [rangeset.last().start] is close to [other.end()],
+// i.e. N iterations of [is_subset()] check are needed if there is no boundary short
+// citcuit (N ~= rangeset.len_ranges()).
+#[allow(clippy::single_range_in_vec_init)]
+fn rangeset_subset_of_boundary_rangeset(rangeset: &RangeSet<u32>) {
+    let other = RangeSet::from(vec![0..9998]);
+    let _ = rangeset.is_subset(&other);
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/utils/src/range/subset.rs
+++ b/utils/src/range/subset.rs
@@ -22,6 +22,7 @@ impl<T: Copy + Ord> Subset<RangeSet<T>> for Range<T> {
             return false;
         }
 
+        // Boundary short circuit.
         if self.start < other.min().unwrap() || self.end > other.end().unwrap() {
             // Check if self's start & end are contained within (or same as) other's.
             return false;
@@ -62,6 +63,7 @@ impl<T: Copy + Ord> Subset<RangeSet<T>> for RangeSet<T> {
             return false;
         }
 
+        // Boundary short circuit.
         if self.min().unwrap() < other.min().unwrap() || self.end().unwrap() > other.end().unwrap()
         {
             // Check if self's start & end are contained within (or same as) other's.

--- a/utils/src/range/subset.rs
+++ b/utils/src/range/subset.rs
@@ -22,6 +22,11 @@ impl<T: Copy + Ord> Subset<RangeSet<T>> for Range<T> {
             return false;
         }
 
+        if self.start < other.min().unwrap() || self.end > other.end().unwrap() {
+            // Check if self's start & end are contained within (or same as) other's.
+            return false;
+        }
+
         for other in &other.ranges {
             if self.start >= other.end {
                 // self is rightward of other, proceed to next other
@@ -54,6 +59,12 @@ impl<T: Copy + Ord> Subset<RangeSet<T>> for RangeSet<T> {
             return true;
         } else if other.ranges.is_empty() {
             // non-empty set is not subset of empty set
+            return false;
+        }
+
+        if self.min().unwrap() < other.min().unwrap() || self.end().unwrap() > other.end().unwrap()
+        {
+            // Check if self's start & end are contained within (or same as) other's.
             return false;
         }
 


### PR DESCRIPTION
As https://github.com/tlsnotary/tlsn/pull/664 starts using `is_subset` checks, I implemented a small optimisation — immediately return false if the subset candidate's left and right boundaries are not within/same as the other rangeset.