### PR TITLE
feat(rand06-compat): rand compat wrapper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "futures-limit",
     "futures-plex",
     "web-spawn",
+    "rand06-compat",
 ]
 
 [workspace.dependencies]

--- a/rand06-compat/Cargo.toml
+++ b/rand06-compat/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "rand06-compat"
+version = "0.1.0"
+edition = "2024"
+description = "Compatibility wrapper between `rand_core` 0.6 and 0.9"
+keywords = ["rand_core", "rand", "compat", "compatibility"]
+
+[features]
+default = ["std"]
+std = ["rand_core_06/std", "rand_core/std"]
+
+[dependencies]
+rand_core = { version = "0.9", default-features = false }
+rand_core_06 = { package = "rand_core", version = "0.6", default-features = false }
+
+[dev-dependencies]
+rand_core = { version = "0.9", default-features = true }
+rand = { version = "0.9" }

--- a/rand06-compat/README.md
+++ b/rand06-compat/README.md
@@ -1,0 +1,26 @@
+# rand06-compat
+
+This crate provides a compatibility wrapper between versions `0.6` and `0.9` of [`rand_core`](https://docs.rs/rand_core/0.9).
+
+# Warning about `no_std` ⚠️
+
+Supporting fallible RNGs is tricky to do in a clean manner. This compat wrapper hardcodes an error code of `1` in the case that the RNG fails.
+
+PRs welcome for a better solution.
+
+# Example
+
+```rust
+use rand_core_06::RngCore as RngCore06;
+use rand_core::OsRng;
+use rand06_compat::Rand0_6CompatExt;
+
+// This function requires an RNG implementing the `0.6` trait.
+fn foo<R>(rng: &mut R) where R: RngCore06 {
+    let num: u32 = rng.next_u32();
+    println!("random number: {}", num);
+}
+
+// Pass in the RNG from `0.9` using compat trait.
+foo(&mut OsRng.compat())
+```

--- a/rand06-compat/src/lib.rs
+++ b/rand06-compat/src/lib.rs
@@ -1,0 +1,118 @@
+#![doc = include_str!("../README.md")]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+/// Compatibility extension trait for RNGs implementing `0.9` `RngCore` trait.
+pub trait Rand0_6CompatExt {
+    /// Wraps `self` in a compatibility wrapper that implements `0.6` traits.
+    fn compat(self) -> Rand0_6CompatWrapper<Self>
+    where
+        Self: Sized,
+    {
+        Rand0_6CompatWrapper(self)
+    }
+
+    /// Wraps `self` in a compatibility wrapper that implements `0.6` traits.
+    ///
+    /// Same as [`Rand0_6CompatExt::compat`] but instead of taking ownership it borrows.
+    fn compat_by_ref(&mut self) -> Rand0_6CompatWrapper<&mut Self>
+    where
+        Self: Sized,
+    {
+        Rand0_6CompatWrapper(self)
+    }
+}
+
+impl<T> Rand0_6CompatExt for T where T: rand_core::TryRngCore + ?Sized {}
+
+/// Rand 0.6 compatibility wrapper.
+pub struct Rand0_6CompatWrapper<R: ?Sized>(R);
+
+impl<R> Rand0_6CompatWrapper<R> {
+    /// Creates a new compatibility wrapper.
+    pub fn new(inner: R) -> Self {
+        Self(inner)
+    }
+
+    /// Returns the inner value.
+    pub fn into_inner(self) -> R {
+        self.0
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<R> rand_core_06::RngCore for Rand0_6CompatWrapper<R>
+where
+    R: rand_core::TryRngCore + ?Sized,
+{
+    fn next_u32(&mut self) -> u32 {
+        self.0.try_next_u32().unwrap()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.0.try_next_u64().unwrap()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.0.try_fill_bytes(dest).unwrap()
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core_06::Error> {
+        self.0
+            .try_fill_bytes(dest)
+            .map_err(|_| rand_core_06::Error::from(core::num::NonZeroU32::new(1).unwrap()))
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R> rand_core_06::RngCore for Rand0_6CompatWrapper<R>
+where
+    R: rand_core::TryRngCore + ?Sized,
+    R::Error: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+{
+    fn next_u32(&mut self) -> u32 {
+        self.0.try_next_u32().unwrap()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.0.try_next_u64().unwrap()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.0.try_fill_bytes(dest).unwrap()
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core_06::Error> {
+        self.0
+            .try_fill_bytes(dest)
+            .map_err(rand_core_06::Error::new)
+    }
+}
+
+impl<R> rand_core_06::CryptoRng for Rand0_6CompatWrapper<R> where R: rand_core::CryptoRng + ?Sized {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use rand_core::OsRng;
+    use rand_core_06::RngCore as RngCore06;
+
+    fn foo<R>(rng: &mut R)
+    where
+        R: RngCore06,
+    {
+        let _: u32 = rng.next_u32();
+    }
+
+    #[test]
+    fn test_compat_os_rng() {
+        foo(&mut OsRng.compat());
+    }
+
+    #[test]
+    fn test_compat_thread_rng() {
+        let mut rng = rand::rng();
+        foo(&mut (rng.compat_by_ref()));
+        foo(&mut rng.compat());
+    }
+}


### PR DESCRIPTION
This PR adds a `rand` compat crate to support our upgrade to `rand` version `0.9`.