### PR TITLE
chore(spansy): remove path location for rangeset dep

### DIFF
--- a/spansy/Cargo.toml
+++ b/spansy/Cargo.toml
@@ -11,7 +11,7 @@ default = []
 serde = ["dep:serde", "bytes/serde", "rangeset/serde"]
 
 [dependencies]
-rangeset = { workspace = true, version = "0.1" }
+rangeset = { version = "0.1" }
 
 bytes.workspace = true
 serde = { workspace = true, features = ["derive"], optional = true }


### PR DESCRIPTION
This PR removes the path location for the `rangeset` dep of `spansy`, instead it uses the crates.io version. This is required because right now we use a git location when depending on `spansy` in `tlsn` which causes version conflicts.