### PR TITLE
feat: Permit parsing of redacted JSON

### DIFF
--- a/spansy/src/json/json.pest
+++ b/spansy/src/json/json.pest
@@ -29,7 +29,7 @@ quoted_string  = _{ "\"" ~ string ~ "\"" }
 string   = @{ (!("\"" | "\\") ~ ANY)* ~ (escape ~ string)? }
 escape  = @{ "\\" ~ ("\"" | "\\" | "/" | "b" | "f" | "n" | "r" | "t" | unicode) }
 unicode = @{ "u" ~ ASCII_HEX_DIGIT{4} }
-redacted = @{ "\\0"+ }
+redacted = @{ "\0"+ }
 
 number = @{ "-"? ~ int ~ ("." ~ ASCII_DIGIT+ ~ exp? | exp)? }
 int    = @{ "0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }

--- a/spansy/src/json/json.pest
+++ b/spansy/src/json/json.pest
@@ -23,12 +23,13 @@ array = { "[" ~ value ~ ("," ~ value)* ~ "]" | "[" ~ "]" }
 //////////////////////
 /// Matches value, e.g.: `"foo"`, `42`, `true`, `null`, `[]`, `{}`.
 //////////////////////
-value = _{ quoted_string | number | object | array | bool | null }
+value = _{ quoted_string | number | object | array | bool | null | redacted }
 
 quoted_string  = _{ "\"" ~ string ~ "\"" }
 string   = @{ (!("\"" | "\\") ~ ANY)* ~ (escape ~ string)? }
 escape  = @{ "\\" ~ ("\"" | "\\" | "/" | "b" | "f" | "n" | "r" | "t" | unicode) }
 unicode = @{ "u" ~ ASCII_HEX_DIGIT{4} }
+redacted = @{ "\\0"+ }
 
 number = @{ "-"? ~ int ~ ("." ~ ASCII_DIGIT+ ~ exp? | exp)? }
 int    = @{ "0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }

--- a/spansy/src/json/json.pest
+++ b/spansy/src/json/json.pest
@@ -29,7 +29,7 @@ quoted_string  = _{ "\"" ~ string ~ "\"" }
 string   = @{ (!("\"" | "\\") ~ ANY)* ~ (escape ~ string)? }
 escape  = @{ "\\" ~ ("\"" | "\\" | "/" | "b" | "f" | "n" | "r" | "t" | unicode) }
 unicode = @{ "u" ~ ASCII_HEX_DIGIT{4} }
-redacted = @{ "\0"+ }
+redacted = @{ "*"+ }
 
 number = @{ "-"? ~ int ~ ("." ~ ASCII_DIGIT+ ~ exp? | exp)? }
 int    = @{ "0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }

--- a/spansy/src/json/mod.rs
+++ b/spansy/src/json/mod.rs
@@ -30,5 +30,5 @@ mod types;
 mod visit;
 
 pub use span::{parse, parse_slice, parse_str};
-pub use types::{Array, Bool, JsonKey, JsonValue, KeyValue, Null, Number, Object, String};
+pub use types::{Array, Bool, JsonKey, JsonValue, KeyValue, Null, Number, Object, Redacted, String};
 pub use visit::JsonVisit;

--- a/spansy/src/json/span.rs
+++ b/spansy/src/json/span.rs
@@ -146,7 +146,7 @@ mod tests {
 
     #[test]
     fn test_json_spanner() {
-        let src = r#"{"foo": "bar", "baz": 123, "quux": { "a": "b", "c": "d" }, "arr": [1, 2, 3], "r_one": \0, "r_many": \0\0\0\0 }"#;
+        let src = "{\"foo\": \"bar\", \"baz\": 123, \"quux\": { \"a\": \"b\", \"c\": \"d\" }, \"arr\": [1, 2, 3], \"r_one\": \0, \"r_many\": \0\0\0\0 }";
 
         let value = parse_str(src).unwrap();
 
@@ -154,8 +154,8 @@ mod tests {
         assert_eq!(value.get("baz").unwrap().span(), "123");
         assert_eq!(value.get("quux.a").unwrap().span(), "b");
         assert_eq!(value.get("arr").unwrap().span(), "[1, 2, 3]");
-        assert_eq!(value.get("r_one").unwrap().span(), r#"\0"#);
-        assert_eq!(value.get("r_many").unwrap().span(), r#"\0\0\0\0"#);
+        assert_eq!(value.get("r_one").unwrap().span(), "\0");
+        assert_eq!(value.get("r_many").unwrap().span(), "\0\0\0\0");
     }
 
     #[test]
@@ -174,14 +174,9 @@ mod tests {
     }
 
     #[test]
-    fn test_redaction_in_key() {
-        let src = r#"{"\0": "bar"}"#;
-        assert!(parse_str(src).is_err());
-    }
-
-    #[test]
+    #[should_panic]
     fn test_redaction_in_value() {
-        let src = r#"{"foo": 1\0\0\0}"#;
-        assert!(parse_str(src).is_err());
+        let src = "{\"foo\": 1\0\0\0}";
+        parse_str(src).unwrap();
     }
 }

--- a/spansy/src/json/types.rs
+++ b/spansy/src/json/types.rs
@@ -534,24 +534,31 @@ mod tests {
     }
 
     #[test]
-    fn test_redacted_value() {
-        let src = r#"\0\0\0"#;
+    fn test_redacted_one_byte() {
+        let src = "\0";
         let value = parse_str(src).unwrap();
-        assert_eq!(value.span(), r#"\0\0\0"#);
+        assert_eq!(value.span(), "\0");
+    }
+
+    #[test]
+    fn test_redacted_value() {
+        let src = "\0\0\0";
+        let value = parse_str(src).unwrap();
+        assert_eq!(value.span(), "\0\0\0");
     }
 
     #[test]
     fn test_redacted_value_in_object() {
-        let src = r#"{"foo": \0\0\0}"#;
+        let src = "{\"foo\": \0\0\0}";
         let value = parse_str(src).unwrap();
-        assert_eq!(value.get("foo").unwrap().span(), r#"\0\0\0"#);
+        assert_eq!(value.get("foo").unwrap().span(), "\0\0\0");
     }
 
     #[test]
     fn test_redacted_value_in_array() {
-        let src = r#"[1, \0\0\0]"#;
+        let src = "[1, \0\0\0]";
         let value = parse_str(src).unwrap();
-        assert_eq!(value.get("1").unwrap().span(), r#"\0\0\0"#);
+        assert_eq!(value.get("1").unwrap().span(), "\0\0\0");
     }
     
     

--- a/spansy/src/json/visit.rs
+++ b/spansy/src/json/visit.rs
@@ -51,6 +51,7 @@ pub trait JsonVisit {
             JsonValue::Bool(value) => self.visit_bool(value),
             JsonValue::Number(value) => self.visit_number(value),
             JsonValue::String(value) => self.visit_string(value),
+            JsonValue::Redacted(value) => self.visit_redacted(value),
             JsonValue::Array(value) => self.visit_array(value),
             JsonValue::Object(value) => self.visit_object(value),
         }
@@ -81,4 +82,7 @@ pub trait JsonVisit {
 
     /// Visit a string value.
     fn visit_string(&mut self, _node: &types::String) {}
+
+    /// Visit a redacted value.
+    fn visit_redacted(&mut self, _node: &types::Redacted) {}
 }


### PR DESCRIPTION
Looking for feedback here.

In parsing partial transcripts, it's necessary to be able to parse JSON which contains redacted values. This change permits verifier to fill redacted values with asterisks, and then parse the resulting JSON such that redacted values can be visited with the specific type of `type::Redacted`.

Are there any undesirable downstream effects of this in existing dependents, which would silently break?