### PR TITLE
fix(web-spawn): call thread destructor

### DIFF
--- a/web-spawn/Cargo.toml
+++ b/web-spawn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web-spawn"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "`std` spawn replacement for WASM in the browser."
 repository = "https://github.com/tlsnotary/tlsn-utils"

--- a/web-spawn/js/spawn.js
+++ b/web-spawn/js/spawn.js
@@ -17,11 +17,13 @@ registerMessageListener(self, 'web_spawn_start_spawner', async (data) => {
     );
     const [module, memory, spawnerPtr] = data;
     const pkg = await import('../../..');
-    await pkg.default({ module, memory });
+    const exports = await pkg.default({ module, memory });
 
     const spawner = pkg.web_spawn_recover_spawner(spawnerPtr);
     postMessage('web_spawn_spawner_ready');
     await spawner.run(workerUrl.toString());
+
+    exports.__wbindgen_thread_destroy();
 
     close();
 });
@@ -31,11 +33,12 @@ registerMessageListener(self, 'web_spawn_start_worker', async (data) => {
     const [module, memory, workerPtr] = data;
 
     const pkg = await import('../../..');
-    await pkg.default({ module, memory });
+    const exports = await pkg.default({ module, memory });
 
     pkg.web_spawn_start_worker(workerPtr);
 
-    wasm.wasm_exports().__wbindgen_thread_destroy();
+    exports.__wbindgen_thread_destroy();
+
     close();
 });
 

--- a/web-spawn/js/spawn.js
+++ b/web-spawn/js/spawn.js
@@ -35,6 +35,7 @@ registerMessageListener(self, 'web_spawn_start_worker', async (data) => {
 
     pkg.web_spawn_start_worker(workerPtr);
 
+    wasm.wasm_exports().__wbindgen_thread_destroy();
     close();
 });
 

--- a/web-spawn/js/spawn.no-bundler.js
+++ b/web-spawn/js/spawn.no-bundler.js
@@ -31,6 +31,8 @@ registerMessageListener(self, 'web_spawn_start_worker', async (data) => {
     wasm.initSync({ module, memory });
     wasm.web_spawn_start_worker(worker);
 
+    wasm.wasm_exports().__wbindgen_thread_destroy();
+
     close();
 });
 

--- a/web-spawn/js/spawn.no-bundler.js
+++ b/web-spawn/js/spawn.no-bundler.js
@@ -14,9 +14,11 @@ registerMessageListener(self, 'web_spawn_start_spawner', async (data) => {
     const [module, memory, workerUrl, wasmUrl, spawner] = data;
     const wasm = await import(`${wasmUrl}`);
 
-    wasm.initSync({ module, memory });
+    const exports = wasm.initSync({ module, memory });
     postMessage('web_spawn_spawner_ready');
     await wasm.web_spawn_recover_spawner(spawner).run(workerUrl);
+
+    exports.__wbindgen_thread_destroy();
 
     URL.revokeObjectURL(workerUrl);
 
@@ -28,10 +30,10 @@ registerMessageListener(self, 'web_spawn_start_worker', async (data) => {
     const [module, memory, wasmUrl, worker] = data;
     const wasm = await import(`${wasmUrl}`);
 
-    wasm.initSync({ module, memory });
+    const exports = wasm.initSync({ module, memory });
     wasm.web_spawn_start_worker(worker);
 
-    wasm.wasm_exports().__wbindgen_thread_destroy();
+    exports.__wbindgen_thread_destroy();
 
     close();
 });

--- a/web-spawn/src/wasm/worker.rs
+++ b/web-spawn/src/wasm/worker.rs
@@ -1,4 +1,4 @@
-use wasm_bindgen::prelude::*;
+use wasm_bindgen::{JsValue, prelude::*};
 
 use crate::wasm::{Closure, thread::Builder};
 
@@ -50,4 +50,10 @@ pub fn web_spawn_start_worker(worker: *mut WorkerData) {
     let WorkerData { f } = unsafe { *Box::from_raw(worker) };
 
     f();
+}
+
+#[wasm_bindgen]
+#[doc(hidden)]
+pub fn wasm_exports() -> JsValue {
+    wasm_bindgen::exports()
 }

--- a/web-spawn/src/wasm/worker.rs
+++ b/web-spawn/src/wasm/worker.rs
@@ -1,4 +1,4 @@
-use wasm_bindgen::{JsValue, prelude::*};
+use wasm_bindgen::prelude::*;
 
 use crate::wasm::{Closure, thread::Builder};
 
@@ -50,10 +50,4 @@ pub fn web_spawn_start_worker(worker: *mut WorkerData) {
     let WorkerData { f } = unsafe { *Box::from_raw(worker) };
 
     f();
-}
-
-#[wasm_bindgen]
-#[doc(hidden)]
-pub fn wasm_exports() -> JsValue {
-    wasm_bindgen::exports()
 }


### PR DESCRIPTION
This PR adds the missing calls to thread destructors, without which there was a memory leak.

Related to: https://github.com/tlsnotary/tlsn/issues/960

With this PR, the memory leak described here https://github.com/tlsnotary/tlsn/pull/946 is gone.