### PR TITLE
feat(web-spawn): optional worker teardown

### DIFF
--- a/web-spawn/js/spawn.js
+++ b/web-spawn/js/spawn.js
@@ -37,6 +37,11 @@ registerMessageListener(self, 'web_spawn_start_worker', async (data) => {
 
     pkg.web_spawn_start_worker(workerPtr);
 
+    // Optional hook – only call if provided by the wasm module.
+    if (typeof exports.__worker_teardown === 'function') {
+        exports.__worker_teardown();
+    }
+
     exports.__wbindgen_thread_destroy();
 
     close();

--- a/web-spawn/js/spawn.no-bundler.js
+++ b/web-spawn/js/spawn.no-bundler.js
@@ -33,6 +33,11 @@ registerMessageListener(self, 'web_spawn_start_worker', async (data) => {
     const exports = wasm.initSync({ module, memory });
     wasm.web_spawn_start_worker(worker);
 
+    // Optional hook – only call if provided by the wasm module.
+    if (typeof exports.__worker_teardown === 'function') {
+        exports.__worker_teardown();
+    }
+
     exports.__wbindgen_thread_destroy();
 
     close();


### PR DESCRIPTION
This PR adds an optional `__worker_teardown` method that can be run before the thread is destoyed.

This can be used to e.g. call worker-specific TLS destructors.

Motivated by https://github.com/tlsnotary/tlsn/pull/1050