### PR TITLE
chore(spansy): update to use rangeset 0.3

### DIFF
--- a/spansy/Cargo.toml
+++ b/spansy/Cargo.toml
@@ -11,7 +11,7 @@ default = []
 serde = ["dep:serde", "bytes/serde", "rangeset/serde"]
 
 [dependencies]
-rangeset = { version = "0.2" }
+rangeset = { version = "0.3" }
 
 bytes.workspace = true
 serde = { workspace = true, features = ["derive"], optional = true }

--- a/spansy/src/http/types.rs
+++ b/spansy/src/http/types.rs
@@ -1,4 +1,8 @@
-use rangeset::{Difference, RangeSet, ToRangeSet};
+use rangeset::{
+    iter::RangeIterator,
+    ops::Difference,
+    set::{RangeSet, ToRangeSet},
+};
 
 use crate::{Span, Spanned, json::JsonValue};
 
@@ -76,7 +80,10 @@ impl Header {
     ///
     /// The indices will include any optional whitespace and the CRLF.
     pub fn without_value(&self) -> RangeSet<usize> {
-        self.span.indices.difference(&self.value.span().indices)
+        self.span
+            .indices
+            .difference(&self.value.span().indices)
+            .into_set()
     }
 
     /// Shifts the span range by the given offset.
@@ -172,7 +179,10 @@ pub struct RequestLine {
 impl RequestLine {
     /// Returns the indices of the request line excluding the request target.
     pub fn without_target(&self) -> RangeSet<usize> {
-        self.span.indices.difference(&self.target.0.indices)
+        self.span
+            .indices
+            .difference(&self.target.0.indices)
+            .into_set()
     }
 
     /// Shifts the span range by the given offset.
@@ -223,12 +233,17 @@ impl Request {
     /// Returns the indices of the request excluding the target, headers and
     /// body.
     pub fn without_data(&self) -> RangeSet<usize> {
-        let mut indices = self.span.indices.difference(&self.request.target.0.indices);
+        let mut indices = self
+            .span
+            .indices
+            .difference(&self.request.target.0.indices)
+            .into_set();
+
         for header in &self.headers {
-            indices = indices.difference(header.span.indices());
+            indices = indices.difference(header.span.indices()).into_set();
         }
         if let Some(body) = &self.body {
-            indices = indices.difference(body.span.indices());
+            indices = indices.difference(body.span.indices()).into_set();
         }
         indices
     }
@@ -378,10 +393,10 @@ impl Response {
     pub fn without_data(&self) -> RangeSet<usize> {
         let mut indices = self.span.indices.clone();
         for header in &self.headers {
-            indices = indices.difference(header.span.indices());
+            indices = indices.difference(header.span.indices()).into_set();
         }
         if let Some(body) = &self.body {
-            indices = indices.difference(body.span.indices());
+            indices = indices.difference(body.span.indices()).into_set();
         }
         indices
     }

--- a/spansy/src/json/types.rs
+++ b/spansy/src/json/types.rs
@@ -1,6 +1,10 @@
 use std::ops::{Index, Range};
 
-use rangeset::{Difference, RangeSet, ToRangeSet};
+use rangeset::{
+    iter::RangeIterator,
+    ops::Difference,
+    set::{RangeSet, ToRangeSet},
+};
 
 use crate::{Span, Spanned};
 
@@ -203,7 +207,10 @@ pub struct KeyValue {
 impl KeyValue {
     /// Returns the indices of the key value pair, excluding the value.
     pub fn without_value(&self) -> RangeSet<usize> {
-        self.span.indices.difference(&self.value.span().indices)
+        self.span
+            .indices
+            .difference(&self.value.span().indices)
+            .into_set()
     }
 
     /// Returns the indices of the key value pair, excluding the trailing
@@ -333,7 +340,7 @@ impl Object {
     pub fn without_pairs(&self) -> RangeSet<usize> {
         let mut indices = self.span.indices.clone();
         for kv in &self.elems {
-            indices = indices.difference(&kv.span.indices);
+            indices = indices.difference(&kv.span.indices).into_set();
         }
         indices
     }
@@ -457,7 +464,8 @@ impl_type!(KeyValue, span);
 
 #[cfg(test)]
 mod tests {
-    use rangeset::IndexRanges;
+
+    use rangeset::ops::Index;
 
     use crate::json::parse_str;
 
@@ -500,7 +508,13 @@ mod tests {
 
         let indices = value.elems[0].without_value();
 
-        assert_eq!(src.index_ranges(&indices), "\"foo\": \"\"");
+        let result: std::string::String = src
+            .as_bytes()
+            .index(indices.iter_ranges())
+            .flatten()
+            .map(|&b| b as char)
+            .collect();
+        assert_eq!(result, "\"foo\": \"\"");
     }
 
     #[test]
@@ -513,7 +527,13 @@ mod tests {
 
         let indices = value.elems[0].without_separator();
 
-        assert_eq!(src.index_ranges(&indices), "\"foo\": \"bar\"");
+        let result: std::string::String = src
+            .as_bytes()
+            .index(indices.iter_ranges())
+            .flatten()
+            .map(|&b| b as char)
+            .collect();
+        assert_eq!(result, "\"foo\": \"bar\"");
     }
 
     #[test]
@@ -526,7 +546,13 @@ mod tests {
 
         let indices = value.without_values();
 
-        assert_eq!(src.index_ranges(&indices), "[]");
+        let result: std::string::String = src
+            .as_bytes()
+            .index(indices.iter_ranges())
+            .flatten()
+            .map(|&b| b as char)
+            .collect();
+        assert_eq!(result, "[]");
     }
 
     #[test]
@@ -539,6 +565,12 @@ mod tests {
 
         let indices = value.without_pairs();
 
-        assert_eq!(src.index_ranges(&indices), "{\n}");
+        let result: std::string::String = src
+            .as_bytes()
+            .index(indices.iter_ranges())
+            .flatten()
+            .map(|&b| b as char)
+            .collect();
+        assert_eq!(result, "{\n}");
     }
 }

--- a/spansy/src/lib.rs
+++ b/spansy/src/lib.rs
@@ -11,7 +11,7 @@ pub(crate) mod helpers;
 pub mod http;
 pub mod json;
 
-use rangeset::{RangeSet, ToRangeSet};
+use rangeset::set::{RangeSet, ToRangeSet};
 
 /// A parsing error.
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
This PR updates the `spansy` crate to use the new `rangeset` 0.3 API