### PR TITLE
chore(web-spawn): remove atomics flag

### DIFF
--- a/web-spawn/.cargo/config.toml
+++ b/web-spawn/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.'cfg(target_arch = "wasm32")']
-rustflags = ["-C", "target-feature=+atomics,+bulk-memory,+mutable-globals"]
+rustflags = ["-C", "target-feature=+bulk-memory,+mutable-globals"]
 
 [unstable]
 build-std = ["panic_abort", "std"]


### PR DESCRIPTION
This PR removes the +atomics wasm rustflag from web-spawn. These flags are only required for web-spawn’s standalone wasm tests; in production, web-spawn is built with the consuming crate’s target flags.

Currently `+atomics` causes errors in the chrome driver. 