### PR TITLE
Add sync `Read` and `Write` support to `futures-plex` crate

### DIFF
--- a/futures-plex/Cargo.toml
+++ b/futures-plex/Cargo.toml
@@ -7,4 +7,4 @@ description = "Port of tokio's `SimplexStream` and `DuplexStream` for the `futur
 [dependencies]
 bytes = { version = "1" }
 futures-io = { version = "0.3" }
-futures-util = { version = "0.3", default-features = false, features = ["io"] }
+futures-util = { version = "0.3", default-features = false, features = ["io", "unstable", "bilock"] }

--- a/futures-plex/Cargo.toml
+++ b/futures-plex/Cargo.toml
@@ -6,5 +6,4 @@ description = "Port of tokio's `SimplexStream` and `DuplexStream` for the `futur
 
 [dependencies]
 bytes = { version = "1" }
-futures-io = { version = "0.3" }
-futures-util = { version = "0.3", default-features = false, features = ["io", "unstable", "bilock"] }
+futures = { version = "0.3", default-features = false, features = ["unstable", "bilock", "executor"] }

--- a/futures-plex/src/half.rs
+++ b/futures-plex/src/half.rs
@@ -1,0 +1,163 @@
+//! Adapted from <https://github.com/rust-lang/futures-rs/blob/master/futures-util/src/io/split.rs>
+//! to support sync operations.
+
+use futures_io::{AsyncRead, AsyncWrite, IoSlice, IoSliceMut};
+use futures_util::{FutureExt, lock::BiLock};
+use std::{
+    fmt,
+    io::{self, Read, Write},
+    pin::Pin,
+    task::{Context, Poll, Waker, ready},
+};
+
+/// The readable half of an object.
+#[derive(Debug)]
+pub struct ReadHalf<T> {
+    handle: BiLock<T>,
+}
+
+/// The writable half of an object.
+#[derive(Debug)]
+pub struct WriteHalf<T> {
+    handle: BiLock<T>,
+}
+
+fn lock_and_then<T, U, E, F>(lock: &BiLock<T>, cx: &mut Context<'_>, f: F) -> Poll<Result<U, E>>
+where
+    F: FnOnce(Pin<&mut T>, &mut Context<'_>) -> Poll<Result<U, E>>,
+{
+    let mut l = ready!(lock.poll_lock(cx));
+    f(l.as_pin_mut(), cx)
+}
+
+pub(crate) fn split<T: AsyncRead + AsyncWrite>(t: T) -> (ReadHalf<T>, WriteHalf<T>) {
+    let (a, b) = BiLock::new(t);
+    (ReadHalf { handle: a }, WriteHalf { handle: b })
+}
+
+impl<T> ReadHalf<T> {
+    /// Checks if this `ReadHalf` and some `WriteHalf` were split from the same
+    /// stream.
+    pub fn is_pair_of(&self, other: &WriteHalf<T>) -> bool {
+        self.handle.is_pair_of(&other.handle)
+    }
+}
+
+impl<T: Unpin> ReadHalf<T> {
+    /// Attempts to put the two "halves" of a split `AsyncRead + AsyncWrite`
+    /// back together. Succeeds only if the `ReadHalf<T>` and `WriteHalf<T>`
+    /// are a matching pair originating from the same call to `split`.
+    pub fn reunite(self, other: WriteHalf<T>) -> Result<T, ReuniteError<T>> {
+        self.handle
+            .reunite(other.handle)
+            .map_err(|err| ReuniteError(Self { handle: err.0 }, WriteHalf { handle: err.1 }))
+    }
+}
+
+impl<T> WriteHalf<T> {
+    /// Checks if this `WriteHalf` and some `ReadHalf` were split from the same
+    /// stream.
+    pub fn is_pair_of(&self, other: &ReadHalf<T>) -> bool {
+        self.handle.is_pair_of(&other.handle)
+    }
+}
+
+impl<T: Unpin> WriteHalf<T> {
+    /// Attempts to put the two "halves" of a split `AsyncRead + AsyncWrite`
+    /// back together. Succeeds only if the `ReadHalf<T>` and `WriteHalf<T>`
+    /// are a matching pair originating from the same call to `split`.
+    pub fn reunite(self, other: ReadHalf<T>) -> Result<T, ReuniteError<T>> {
+        other.reunite(self)
+    }
+}
+
+impl<R: AsyncRead> AsyncRead for ReadHalf<R> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        lock_and_then(&self.handle, cx, |l, cx| l.poll_read(cx, buf))
+    }
+
+    fn poll_read_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &mut [IoSliceMut<'_>],
+    ) -> Poll<io::Result<usize>> {
+        lock_and_then(&self.handle, cx, |l, cx| l.poll_read_vectored(cx, bufs))
+    }
+}
+
+impl<W: AsyncWrite> AsyncWrite for WriteHalf<W> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        lock_and_then(&self.handle, cx, |l, cx| l.poll_write(cx, buf))
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        lock_and_then(&self.handle, cx, |l, cx| l.poll_write_vectored(cx, bufs))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        lock_and_then(&self.handle, cx, |l, cx| l.poll_flush(cx))
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        lock_and_then(&self.handle, cx, |l, cx| l.poll_close(cx))
+    }
+}
+
+impl<R: Read + Unpin> Read for ReadHalf<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut cx = Context::from_waker(Waker::noop());
+        let Poll::Ready(mut handle) = self.handle.lock().poll_unpin(&mut cx) else {
+            return Ok(0);
+        };
+
+        handle.as_pin_mut().read(buf)
+    }
+}
+
+impl<W: Write + Unpin> Write for WriteHalf<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut cx = Context::from_waker(Waker::noop());
+        let Poll::Ready(mut handle) = self.handle.lock().poll_unpin(&mut cx) else {
+            return Ok(0);
+        };
+
+        handle.as_pin_mut().write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Error indicating a `ReadHalf<T>` and `WriteHalf<T>` were not two halves
+/// of a `AsyncRead + AsyncWrite`, and thus could not be `reunite`d.
+pub struct ReuniteError<T>(pub ReadHalf<T>, pub WriteHalf<T>);
+
+impl<T> fmt::Debug for ReuniteError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("ReuniteError").field(&"...").finish()
+    }
+}
+
+impl<T> fmt::Display for ReuniteError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "tried to reunite a ReadHalf and WriteHalf that don't form a pair"
+        )
+    }
+}
+
+impl<T: core::any::Any> std::error::Error for ReuniteError<T> {}

--- a/futures-plex/src/half.rs
+++ b/futures-plex/src/half.rs
@@ -119,7 +119,10 @@ impl<R: Read + Unpin> Read for ReadHalf<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut cx = Context::from_waker(Waker::noop());
         let Poll::Ready(mut handle) = self.handle.lock().poll_unpin(&mut cx) else {
-            return Ok(0);
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WouldBlock,
+                "unable to acquire lock",
+            ));
         };
 
         handle.as_pin_mut().read(buf)
@@ -130,7 +133,10 @@ impl<W: Write + Unpin> Write for WriteHalf<W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let mut cx = Context::from_waker(Waker::noop());
         let Poll::Ready(mut handle) = self.handle.lock().poll_unpin(&mut cx) else {
-            return Ok(0);
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WouldBlock,
+                "unable to acquire lock",
+            ));
         };
 
         handle.as_pin_mut().write(buf)

--- a/futures-plex/src/half.rs
+++ b/futures-plex/src/half.rs
@@ -8,7 +8,7 @@ use futures::{
 };
 use std::{
     fmt,
-    io::{self, Read, Write},
+    io::{self},
     pin::Pin,
     task::{Context, Poll, ready},
 };
@@ -117,24 +117,6 @@ impl<W: AsyncWrite> AsyncWrite for WriteHalf<W> {
 
     fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         lock_and_then(&self.handle, cx, |l, cx| l.poll_close(cx))
-    }
-}
-
-impl<R: Read + Unpin> Read for ReadHalf<R> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let mut handle = futures::executor::block_on(self.handle.lock());
-        handle.as_pin_mut().read(buf)
-    }
-}
-
-impl<W: Write + Unpin> Write for WriteHalf<W> {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let mut handle = futures::executor::block_on(self.handle.lock());
-        handle.as_pin_mut().write(buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
     }
 }
 

--- a/futures-plex/src/half.rs
+++ b/futures-plex/src/half.rs
@@ -1,14 +1,19 @@
 //! Adapted from <https://github.com/rust-lang/futures-rs/blob/master/futures-util/src/io/split.rs>
 //! to support sync operations.
 
-use futures_io::{AsyncRead, AsyncWrite, IoSlice, IoSliceMut};
-use futures_util::{FutureExt, lock::BiLock};
+use futures::{
+    AsyncRead, AsyncWrite,
+    io::{IoSlice, IoSliceMut},
+    lock::BiLock,
+};
 use std::{
     fmt,
     io::{self, Read, Write},
     pin::Pin,
-    task::{Context, Poll, Waker, ready},
+    task::{Context, Poll, ready},
 };
+
+use crate::SimplexStream;
 
 /// The readable half of an object.
 #[derive(Debug)]
@@ -117,33 +122,35 @@ impl<W: AsyncWrite> AsyncWrite for WriteHalf<W> {
 
 impl<R: Read + Unpin> Read for ReadHalf<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let mut cx = Context::from_waker(Waker::noop());
-        let Poll::Ready(mut handle) = self.handle.lock().poll_unpin(&mut cx) else {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::WouldBlock,
-                "unable to acquire lock",
-            ));
-        };
-
+        let mut handle = futures::executor::block_on(self.handle.lock());
         handle.as_pin_mut().read(buf)
     }
 }
 
 impl<W: Write + Unpin> Write for WriteHalf<W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let mut cx = Context::from_waker(Waker::noop());
-        let Poll::Ready(mut handle) = self.handle.lock().poll_unpin(&mut cx) else {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::WouldBlock,
-                "unable to acquire lock",
-            ));
-        };
-
+        let mut handle = futures::executor::block_on(self.handle.lock());
         handle.as_pin_mut().write(buf)
     }
 
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
+    }
+}
+
+impl ReadHalf<SimplexStream> {
+    /// Returns the number of bytes that can be read.
+    pub fn remaining(&self) -> usize {
+        let handle = futures::executor::block_on(self.handle.lock());
+        handle.remaining()
+    }
+}
+
+impl WriteHalf<SimplexStream> {
+    /// Returns the number of bytes that can be written.
+    pub fn remaining_mut(&self) -> usize {
+        let handle = futures::executor::block_on(self.handle.lock());
+        handle.remaining_mut()
     }
 }
 

--- a/futures-plex/src/lib.rs
+++ b/futures-plex/src/lib.rs
@@ -1,16 +1,16 @@
 #![doc = include_str!("../README.md")]
 
 use std::{
+    io::{Read, Write},
     pin::Pin,
     task::{self, Poll, Waker},
 };
 
 use bytes::{Buf, BytesMut};
 use futures_io::{AsyncRead, AsyncWrite};
-use futures_util::{
-    AsyncReadExt,
-    io::{ReadHalf, WriteHalf},
-};
+
+mod half;
+pub use half::{ReadHalf, WriteHalf};
 
 /// A bidirectional pipe to read and write bytes in memory.
 ///
@@ -102,8 +102,8 @@ pub struct SimplexStream {
 /// The `max_buf_size` argument is the maximum amount of bytes that can be
 /// written to a side before the write returns `Poll::Pending`.
 pub fn duplex(max_buf_size: usize) -> (DuplexStream, DuplexStream) {
-    let (read_0, write_0) = SimplexStream::new_unsplit(max_buf_size).split();
-    let (read_1, write_1) = SimplexStream::new_unsplit(max_buf_size).split();
+    let (read_0, write_0) = half::split(SimplexStream::new_unsplit(max_buf_size));
+    let (read_1, write_1) = half::split(SimplexStream::new_unsplit(max_buf_size));
 
     (
         DuplexStream {
@@ -168,6 +168,22 @@ impl AsyncWrite for DuplexStream {
     }
 }
 
+impl Read for DuplexStream {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        Read::read(&mut self.read, buf)
+    }
+}
+
+impl Write for DuplexStream {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        Write::write(&mut self.write, buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Write::flush(&mut self.write)
+    }
+}
+
 // ===== impl SimplexStream =====
 
 /// Creates unidirectional buffer that acts like in memory pipe.
@@ -196,7 +212,7 @@ impl AsyncWrite for DuplexStream {
 /// # }
 /// ```
 pub fn simplex(max_buf_size: usize) -> (ReadHalf<SimplexStream>, WriteHalf<SimplexStream>) {
-    SimplexStream::new_unsplit(max_buf_size).split()
+    half::split(SimplexStream::new_unsplit(max_buf_size))
 }
 
 impl SimplexStream {
@@ -340,5 +356,48 @@ impl AsyncWrite for SimplexStream {
     ) -> Poll<std::io::Result<()>> {
         self.close_write();
         Poll::Ready(Ok(()))
+    }
+}
+
+impl Read for SimplexStream {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.buffer.has_remaining() {
+            let len = self.buffer.remaining().min(buf.len());
+            buf[..len].copy_from_slice(&self.buffer[..len]);
+            self.buffer.advance(len);
+            if len > 0 {
+                // The passed `buf` might have been empty, don't wake up if
+                // no bytes have been moved.
+                if let Some(waker) = self.write_waker.take() {
+                    waker.wake();
+                }
+            }
+            Ok(len)
+        } else {
+            Ok(0)
+        }
+    }
+}
+
+impl Write for SimplexStream {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        if self.is_closed {
+            return Err(std::io::ErrorKind::BrokenPipe.into());
+        }
+        let avail = self.max_buf_size - self.buffer.len();
+        if avail == 0 {
+            return Ok(0);
+        }
+
+        let len = buf.len().min(avail);
+        self.buffer.extend_from_slice(&buf[..len]);
+        if let Some(waker) = self.read_waker.take() {
+            waker.wake();
+        }
+        Ok(len)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
     }
 }

--- a/futures-plex/src/lib.rs
+++ b/futures-plex/src/lib.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use bytes::{Buf, BytesMut};
-use futures_io::{AsyncRead, AsyncWrite};
+use futures::{AsyncRead, AsyncWrite};
 
 mod half;
 pub use half::{ReadHalf, WriteHalf};
@@ -30,7 +30,7 @@ pub use half::{ReadHalf, WriteHalf};
 ///
 /// ```
 /// # async fn ex() -> std::io::Result<()> {
-/// # use futures_util::{AsyncReadExt, AsyncWriteExt};
+/// # use futures::{AsyncReadExt, AsyncWriteExt};
 /// let (mut client, mut server) = futures_plex::duplex(64);
 ///
 /// client.write_all(b"ping").await?;
@@ -52,6 +52,18 @@ pub struct DuplexStream {
     write: WriteHalf<SimplexStream>,
 }
 
+impl DuplexStream {
+    /// Returns the number of bytes that can be read.
+    pub fn remaining(&self) -> usize {
+        self.read.remaining()
+    }
+
+    /// Returns the number of bytes that can be written.
+    pub fn remaining_mut(&self) -> usize {
+        self.write.remaining_mut()
+    }
+}
+
 /// A unidirectional pipe to read and write bytes in memory.
 ///
 /// It can be constructed by [`simplex`] function which will create a pair of
@@ -62,7 +74,7 @@ pub struct DuplexStream {
 ///
 /// ```
 /// # async fn ex() -> std::io::Result<()> {
-/// # use futures_util::{AsyncReadExt, AsyncWriteExt};
+/// # use futures::{AsyncReadExt, AsyncWriteExt};
 /// let (mut receiver, mut sender) = futures_plex::simplex(64);
 ///
 /// sender.write_all(b"ping").await?;
@@ -200,7 +212,7 @@ impl Write for DuplexStream {
 ///
 /// ```
 /// # async fn ex() -> std::io::Result<()> {
-/// # use futures_util::{AsyncReadExt, AsyncWriteExt};
+/// # use futures::{AsyncReadExt, AsyncWriteExt};
 /// let (reader, writer) = futures_plex::simplex(64);
 /// let mut simplex_stream = reader.reunite(writer).unwrap();
 /// simplex_stream.write_all(b"hello").await?;
@@ -230,6 +242,16 @@ impl SimplexStream {
             read_waker: None,
             write_waker: None,
         }
+    }
+
+    /// Returns the number of bytes that can be read from this buffer.
+    pub fn remaining(&self) -> usize {
+        self.buffer.remaining()
+    }
+
+    /// Returns the number of bytes that can be written into this buffer.
+    pub fn remaining_mut(&self) -> usize {
+        self.max_buf_size - self.buffer.remaining()
     }
 
     fn close_write(&mut self) {

--- a/futures-plex/src/lib.rs
+++ b/futures-plex/src/lib.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use bytes::{Buf, BytesMut};
-use futures::{AsyncRead, AsyncWrite};
+use futures::{AsyncRead, AsyncWrite, future::poll_fn};
 
 mod half;
 pub use half::{ReadHalf, WriteHalf};
@@ -182,17 +182,19 @@ impl AsyncWrite for DuplexStream {
 
 impl Read for DuplexStream {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        Read::read(&mut self.read, buf)
+        let fut = poll_fn(|cx| AsyncRead::poll_read(Pin::new(self), cx, buf));
+        futures::executor::block_on(fut)
     }
 }
 
 impl Write for DuplexStream {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        Write::write(&mut self.write, buf)
+        let fut = poll_fn(|cx| AsyncWrite::poll_write(Pin::new(self), cx, buf));
+        futures::executor::block_on(fut)
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
-        Write::flush(&mut self.write)
+        Ok(())
     }
 }
 
@@ -383,40 +385,15 @@ impl AsyncWrite for SimplexStream {
 
 impl Read for SimplexStream {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        if self.buffer.has_remaining() {
-            let len = self.buffer.remaining().min(buf.len());
-            buf[..len].copy_from_slice(&self.buffer[..len]);
-            self.buffer.advance(len);
-            if len > 0 {
-                // The passed `buf` might have been empty, don't wake up if
-                // no bytes have been moved.
-                if let Some(waker) = self.write_waker.take() {
-                    waker.wake();
-                }
-            }
-            Ok(len)
-        } else {
-            Ok(0)
-        }
+        let fut = poll_fn(|cx| AsyncRead::poll_read(Pin::new(self), cx, buf));
+        futures::executor::block_on(fut)
     }
 }
 
 impl Write for SimplexStream {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        if self.is_closed {
-            return Err(std::io::ErrorKind::BrokenPipe.into());
-        }
-        let avail = self.max_buf_size - self.buffer.len();
-        if avail == 0 {
-            return Ok(0);
-        }
-
-        let len = buf.len().min(avail);
-        self.buffer.extend_from_slice(&buf[..len]);
-        if let Some(waker) = self.read_waker.take() {
-            waker.wake();
-        }
-        Ok(len)
+        let fut = poll_fn(|cx| AsyncWrite::poll_write(Pin::new(self), cx, buf));
+        futures::executor::block_on(fut)
     }
 
     fn flush(&mut self) -> std::io::Result<()> {


### PR DESCRIPTION
This PR adds sync `Read` and `Write` support for `SimplexStream` and `DuplexStream`.