### PR TITLE
chore(spansy): update to use rangeset 0.4

### DIFF
--- a/spansy/Cargo.toml
+++ b/spansy/Cargo.toml
@@ -11,11 +11,11 @@ default = []
 serde = ["dep:serde", "bytes/serde", "rangeset/serde"]
 
 [dependencies]
-rangeset = { version = "0.3" }
+rangeset = { version = "0.4" }
 
-bytes.workspace = true
+bytes = { workspace = true }
 serde = { workspace = true, features = ["derive"], optional = true }
-thiserror.workspace = true
+thiserror = { workspace = true }
 
 httparse = "1.8"
 pest = { version = "2.7" }

--- a/spansy/src/http/types.rs
+++ b/spansy/src/http/types.rs
@@ -1,6 +1,6 @@
 use rangeset::{
     iter::RangeIterator,
-    ops::Difference,
+    ops::Set,
     set::{RangeSet, ToRangeSet},
 };
 

--- a/spansy/src/json/types.rs
+++ b/spansy/src/json/types.rs
@@ -2,7 +2,7 @@ use std::ops::{Index, Range};
 
 use rangeset::{
     iter::RangeIterator,
-    ops::Difference,
+    ops::Set,
     set::{RangeSet, ToRangeSet},
 };
 
@@ -464,9 +464,6 @@ impl_type!(KeyValue, span);
 
 #[cfg(test)]
 mod tests {
-
-    use rangeset::ops::Index;
-
     use crate::json::parse_str;
 
     use super::*;
@@ -508,11 +505,9 @@ mod tests {
 
         let indices = value.elems[0].without_value();
 
-        let result: std::string::String = src
-            .as_bytes()
-            .index(indices.iter_ranges())
-            .flatten()
-            .map(|&b| b as char)
+        let result: std::string::String = indices
+            .iter_values()
+            .map(|i| src.as_bytes()[i] as char)
             .collect();
         assert_eq!(result, "\"foo\": \"\"");
     }
@@ -527,11 +522,9 @@ mod tests {
 
         let indices = value.elems[0].without_separator();
 
-        let result: std::string::String = src
-            .as_bytes()
-            .index(indices.iter_ranges())
-            .flatten()
-            .map(|&b| b as char)
+        let result: std::string::String = indices
+            .iter_values()
+            .map(|i| src.as_bytes()[i] as char)
             .collect();
         assert_eq!(result, "\"foo\": \"bar\"");
     }
@@ -546,11 +539,9 @@ mod tests {
 
         let indices = value.without_values();
 
-        let result: std::string::String = src
-            .as_bytes()
-            .index(indices.iter_ranges())
-            .flatten()
-            .map(|&b| b as char)
+        let result: std::string::String = indices
+            .iter_values()
+            .map(|i| src.as_bytes()[i] as char)
             .collect();
         assert_eq!(result, "[]");
     }
@@ -565,11 +556,9 @@ mod tests {
 
         let indices = value.without_pairs();
 
-        let result: std::string::String = src
-            .as_bytes()
-            .index(indices.iter_ranges())
-            .flatten()
-            .map(|&b| b as char)
+        let result: std::string::String = indices
+            .iter_values()
+            .map(|i| src.as_bytes()[i] as char)
             .collect();
         assert_eq!(result, "{\n}");
     }

--- a/spansy/src/json/visit.rs
+++ b/spansy/src/json/visit.rs
@@ -16,7 +16,7 @@ use super::{types, types::JsonValue};
 /// impl<'a> JsonVisit for DigitReplacer<'a, '_> {
 ///     fn visit_number(&mut self, node: &Number) {
 ///         let span = node.span();
-///         for range in span.indices().iter_ranges() {
+///         for range in span.indices().iter() {
 ///             let replacement = self.digit.repeat(range.len());
 ///             self.src.replace_range(range, &replacement);
 ///         }


### PR DESCRIPTION
This PR updates `spansy` to use `rangeset` 0.4 API.