### PR TITLE
feat(websocket-relay): enable TCP_NODELAY for lower latency

### DIFF
--- a/websocket-relay/src/lib.rs
+++ b/websocket-relay/src/lib.rs
@@ -148,6 +148,7 @@ async fn handle_ws(id: ConnectionId, ws: WebSocketStream<TcpStream>) -> Result<(
 #[instrument(level = "debug", skip(ws), err)]
 async fn handle_tcp(addr: String, ws: WebSocketStream<TcpStream>) -> Result<()> {
     let mut tcp = TcpStream::connect(addr).await?;
+    tcp.set_nodelay(true)?;
 
     let (mut sink, mut stream) = ws.split();
     let (mut rx, mut tx) = tcp.split();


### PR DESCRIPTION
This PR enables TCP_NODELAY for lower latency.

This will be needed in our harness. 