### PR TITLE
feat(websocket-relay): add ability to bind to a local address

### DIFF
--- a/websocket-relay/Cargo.toml
+++ b/websocket-relay/Cargo.toml
@@ -16,3 +16,6 @@ tokio = { workspace = true, features = ["full"] }
 tokio-tungstenite = { version = "0.23", features = ["url"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+
+[dev-dependencies]
+tokio-tungstenite = { version = "0.23", features = ["connect"] }

--- a/websocket-relay/src/lib.rs
+++ b/websocket-relay/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, Ordering},
@@ -12,13 +12,86 @@ use futures::{SinkExt, StreamExt as _};
 use once_cell::sync::Lazy;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
-    net::{TcpListener, TcpStream},
+    net::{TcpListener, TcpSocket, TcpStream},
 };
 use tokio_tungstenite::{
     WebSocketStream, accept_hdr_async,
     tungstenite::{Message, http::Request},
 };
 use tracing::{debug, info, instrument};
+
+/// WebSocket relay server.
+#[derive(Debug, Clone, Default)]
+pub struct Relay {
+    /// Local address to bind outgoing TCP connections to.
+    ///
+    /// If set, the relay will bind to this address before connecting to the
+    /// target TCP server. This is useful for controlling the source IP address
+    /// of outgoing connections.
+    ///
+    /// If not set, the operating system will choose the source address based on
+    /// the routing table.
+    local_address: Option<IpAddr>,
+}
+
+impl Relay {
+    /// Creates a new relay builder.
+    pub fn builder() -> RelayBuilder {
+        RelayBuilder::default()
+    }
+
+    /// Runs the websocket relay server with the given TCP listener.
+    #[instrument(skip(self))]
+    pub async fn run(&self, listener: TcpListener) -> Result<()> {
+        loop {
+            let (socket, addr) = listener.accept().await?;
+            info!("accepted connection from: {}", addr);
+
+            let relay = self.clone();
+            tokio::spawn(async move { relay.handle_connection(addr, socket).await });
+        }
+    }
+
+    #[instrument(skip(self, io), err)]
+    async fn handle_connection(&self, addr: SocketAddr, io: TcpStream) -> Result<()> {
+        match accept_ws(io).await? {
+            Mode::Ws { id, ws } => {
+                tokio::spawn(handle_ws(id, ws));
+            }
+            Mode::Tcp { addr, ws } => {
+                let local_address = self.local_address;
+                tokio::spawn(handle_tcp(addr, local_address, ws));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Builder for [`Relay`].
+#[derive(Debug, Default)]
+pub struct RelayBuilder {
+    local_address: Option<IpAddr>,
+}
+
+impl RelayBuilder {
+    /// Sets the local address to bind outgoing TCP connections to.
+    ///
+    /// This controls the source IP address used when connecting to target TCP
+    /// servers. If not set, the operating system will choose the source address
+    /// based on the routing table.
+    pub fn local_address(mut self, addr: IpAddr) -> Self {
+        self.local_address = Some(addr);
+        self
+    }
+
+    /// Builds the relay.
+    pub fn build(self) -> Relay {
+        Relay {
+            local_address: self.local_address,
+        }
+    }
+}
 
 #[derive(Debug, Default)]
 struct State {
@@ -44,28 +117,12 @@ enum Mode {
 }
 
 /// Runs the websocket relay server with the given TCP listener.
+///
+/// This is a convenience function that creates a default [`Relay`] and runs it.
+/// For more control over the relay configuration, use [`Relay::builder()`].
 #[instrument]
 pub async fn run(listener: TcpListener) -> Result<()> {
-    loop {
-        let (socket, addr) = listener.accept().await?;
-        info!("accepted connection from: {}", addr);
-
-        tokio::spawn(handle_connection(addr, socket));
-    }
-}
-
-#[instrument(skip(io), err)]
-async fn handle_connection(addr: SocketAddr, io: TcpStream) -> Result<()> {
-    match accept_ws(io).await? {
-        Mode::Ws { id, ws } => {
-            tokio::spawn(handle_ws(id, ws));
-        }
-        Mode::Tcp { addr, ws } => {
-            tokio::spawn(handle_tcp(addr, ws));
-        }
-    }
-
-    Ok(())
+    Relay::default().run(listener).await
 }
 
 #[instrument(level = "debug", skip_all, err)]
@@ -146,8 +203,19 @@ async fn handle_ws(id: ConnectionId, ws: WebSocketStream<TcpStream>) -> Result<(
 
 /// Relays data between a websocket client and a TCP server.
 #[instrument(level = "debug", skip(ws), err)]
-async fn handle_tcp(addr: String, ws: WebSocketStream<TcpStream>) -> Result<()> {
-    let mut tcp = TcpStream::connect(addr).await?;
+async fn handle_tcp(
+    addr: String,
+    local_address: Option<IpAddr>,
+    ws: WebSocketStream<TcpStream>,
+) -> Result<()> {
+    let mut tcp = match local_address {
+        Some(local_addr) => {
+            let socket = TcpSocket::new_v4()?;
+            socket.bind(SocketAddr::new(local_addr, 0))?;
+            socket.connect(addr.parse()?).await?
+        }
+        None => TcpStream::connect(addr).await?,
+    };
     tcp.set_nodelay(true)?;
 
     let (mut sink, mut stream) = ws.split();

--- a/websocket-relay/tests/integration.rs
+++ b/websocket-relay/tests/integration.rs
@@ -8,15 +8,12 @@ use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::TcpListener,
 };
-use tokio_tungstenite::{
-    MaybeTlsStream, WebSocketStream,
-    connect_async,
-    tungstenite::Message,
-};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async, tungstenite::Message};
 use websocket_relay::Relay;
 
 /// Connect to a WebSocket server with retries.
-/// Retries on connection refused errors, useful for waiting until server is ready.
+/// Retries on connection refused errors, useful for waiting until server is
+/// ready.
 async fn connect_with_retry(url: &str) -> WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>> {
     for _ in 0..50 {
         match connect_async(url).await {

--- a/websocket-relay/tests/integration.rs
+++ b/websocket-relay/tests/integration.rs
@@ -1,0 +1,182 @@
+use std::{
+    net::{IpAddr, Ipv4Addr},
+    time::Duration,
+};
+
+use futures::{SinkExt, StreamExt};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
+use tokio_tungstenite::{
+    MaybeTlsStream, WebSocketStream,
+    connect_async,
+    tungstenite::Message,
+};
+use websocket_relay::Relay;
+
+/// Connect to a WebSocket server with retries.
+/// Retries on connection refused errors, useful for waiting until server is ready.
+async fn connect_with_retry(url: &str) -> WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>> {
+    for _ in 0..50 {
+        match connect_async(url).await {
+            Ok((ws, _)) => return ws,
+            Err(_) => tokio::time::sleep(Duration::from_millis(10)).await,
+        }
+    }
+    panic!("failed to connect to {} after retries", url);
+}
+
+/// Test that the relay can proxy between a WebSocket client and a TCP server.
+#[tokio::test]
+async fn test_tcp_relay() {
+    // Start a simple TCP echo server
+    let tcp_server = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let tcp_addr = tcp_server.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let (mut socket, _) = tcp_server.accept().await.unwrap();
+        let mut buf = [0u8; 1024];
+        loop {
+            let n = socket.read(&mut buf).await.unwrap();
+            if n == 0 {
+                break;
+            }
+            socket.write_all(&buf[..n]).await.unwrap();
+        }
+    });
+
+    // Start the relay
+    let relay_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let relay_addr = relay_listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        Relay::default().run(relay_listener).await.unwrap();
+    });
+
+    // Connect to the relay via WebSocket (retries until ready)
+    let url = format!("ws://{}/tcp?addr={}", relay_addr, tcp_addr);
+    let mut ws = connect_with_retry(&url).await;
+
+    // Send data through the relay
+    let test_data = b"hello world";
+    ws.send(Message::Binary(test_data.to_vec())).await.unwrap();
+
+    // Receive echoed data
+    let msg = ws.next().await.unwrap().unwrap();
+    assert_eq!(msg, Message::Binary(test_data.to_vec()));
+
+    // Close the connection
+    ws.close(None).await.unwrap();
+}
+
+/// Test that the relay can proxy between two WebSocket clients.
+#[tokio::test]
+async fn test_ws_relay() {
+    // Start the relay
+    let relay_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let relay_addr = relay_listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        Relay::default().run(relay_listener).await.unwrap();
+    });
+
+    // Connect two clients with the same ID (first connect retries until ready)
+    let url = format!("ws://{}/ws?id=test123", relay_addr);
+    let mut ws1 = connect_with_retry(&url).await;
+    let mut ws2 = connect_with_retry(&url).await;
+
+    // Send from client 1 to client 2
+    let test_data = b"hello from client 1";
+    ws1.send(Message::Binary(test_data.to_vec())).await.unwrap();
+
+    let msg = ws2.next().await.unwrap().unwrap();
+    assert_eq!(msg, Message::Binary(test_data.to_vec()));
+
+    // Send from client 2 to client 1
+    let test_data = b"hello from client 2";
+    ws2.send(Message::Binary(test_data.to_vec())).await.unwrap();
+
+    let msg = ws1.next().await.unwrap().unwrap();
+    assert_eq!(msg, Message::Binary(test_data.to_vec()));
+
+    // Close connections
+    ws1.close(None).await.unwrap();
+    ws2.close(None).await.unwrap();
+}
+
+/// Test that the relay builder API works with local_address.
+/// This test verifies the API compiles and runs without error.
+/// Actual source IP verification would require network namespaces.
+#[tokio::test]
+async fn test_tcp_relay_with_local_address() {
+    // Start a simple TCP server that accepts one connection
+    let tcp_server = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let tcp_addr = tcp_server.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let (mut socket, _) = tcp_server.accept().await.unwrap();
+        let mut buf = [0u8; 1024];
+        let n = socket.read(&mut buf).await.unwrap();
+        socket.write_all(&buf[..n]).await.unwrap();
+    });
+
+    // Start the relay with local_address set to loopback
+    let relay_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let relay_addr = relay_listener.local_addr().unwrap();
+
+    let relay = Relay::builder()
+        .local_address(IpAddr::V4(Ipv4Addr::LOCALHOST))
+        .build();
+
+    tokio::spawn(async move {
+        relay.run(relay_listener).await.unwrap();
+    });
+
+    // Connect and verify it works (retries until ready)
+    let url = format!("ws://{}/tcp?addr={}", relay_addr, tcp_addr);
+    let mut ws = connect_with_retry(&url).await;
+
+    let test_data = b"test with local_address";
+    ws.send(Message::Binary(test_data.to_vec())).await.unwrap();
+
+    let msg = ws.next().await.unwrap().unwrap();
+    assert_eq!(msg, Message::Binary(test_data.to_vec()));
+
+    ws.close(None).await.unwrap();
+}
+
+/// Test the backwards-compatible run() function.
+#[tokio::test]
+async fn test_run_function() {
+    // Start a simple TCP echo server
+    let tcp_server = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let tcp_addr = tcp_server.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let (mut socket, _) = tcp_server.accept().await.unwrap();
+        let mut buf = [0u8; 1024];
+        let n = socket.read(&mut buf).await.unwrap();
+        socket.write_all(&buf[..n]).await.unwrap();
+    });
+
+    // Start the relay using the standalone run() function
+    let relay_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let relay_addr = relay_listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        websocket_relay::run(relay_listener).await.unwrap();
+    });
+
+    // Connect and verify it works (retries until ready)
+    let url = format!("ws://{}/tcp?addr={}", relay_addr, tcp_addr);
+    let mut ws = connect_with_retry(&url).await;
+
+    let test_data = b"test run function";
+    ws.send(Message::Binary(test_data.to_vec())).await.unwrap();
+
+    let msg = ws.next().await.unwrap().unwrap();
+    assert_eq!(msg, Message::Binary(test_data.to_vec()));
+
+    ws.close(None).await.unwrap();
+}


### PR DESCRIPTION
This PR adds `local_address` option to WebSocket relay. This will be used by `tlsn` harness.

- Add builder API for Relay with optional local_address configuration                                                                           
-  This allows controlling the source IP address for outgoing TCP connections                                                                    
- Add integration tests for the relay   

See also https://github.com/tlsnotary/tlsn/pull/1091