### PR TITLE
Fix deprecation warning and pin Rust toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,7 +51,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ env.RUST_VERSION }}
+          toolchain: nightly
+          components: rustfmt
       - uses: Swatinem/rust-cache@v2.7.7
       - name: Check formatting
         run: cargo fmt --check --all

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+  RUST_VERSION: "1.93.0"
 
 jobs:
   build_and_test:
@@ -18,10 +19,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install stable rust toolchain
+      - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: ${{ env.RUST_VERSION }}
           components: clippy
 
       - name: Use caching
@@ -49,6 +50,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2.7.7
       - name: Check formatting
         run: cargo fmt --check --all

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,7 +68,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown,x86_64-unknown-linux-gnu
-          toolchain: nightly
+          # Pin nightly due to rustc regression with wasm32 shared memory
+          # See: https://github.com/wasm-bindgen/wasm-bindgen/issues/4727
+          toolchain: "nightly-2025-09-24"
           components: rust-src
 
       - name: Install wasm-pack

--- a/mux/mux/src/connection/active.rs
+++ b/mux/mux/src/connection/active.rs
@@ -393,7 +393,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
     pub(super) fn new_stream(&mut self, user_id: &[u8]) -> Result<Stream> {
         let stream = self.registry.lock().new_stream(user_id)?;
         // Drain new receivers immediately so they're available before poll
-        while let Ok(Some(receiver)) = self.new_receiver_rx.try_next() {
+        while let Ok(receiver) = self.new_receiver_rx.try_recv() {
             self.stream_receivers.push(receiver);
         }
         Ok(stream)

--- a/web-spawn/rust-toolchain
+++ b/web-spawn/rust-toolchain
@@ -1,2 +1,4 @@
 [toolchain]
-channel = "nightly"
+# Pinned due to rustc regression with wasm32 shared memory
+# See: https://github.com/wasm-bindgen/wasm-bindgen/issues/4727
+channel = "nightly-2025-09-24"


### PR DESCRIPTION
## Summary
- Replace deprecated `try_next()` with `try_recv()` in mux connection
- Pin CI Rust toolchain to 1.93.0 via `RUST_VERSION` env var (WASM job remains on nightly due to `build-std`)

Fixes #99