### PR TITLE
fix(web-spawn): declare web-sys/Worker feature

### DIFF
--- a/web-spawn/Cargo.toml
+++ b/web-spawn/Cargo.toml
@@ -17,6 +17,7 @@ wasm-bindgen-futures = { version = "0.4" }
 crossbeam-channel = { version = "0.5" }
 js-sys = { version = "0.3" }
 web-sys = { version = "0.3", features = [
+    "Worker",
     "WorkerOptions",
     "WorkerType",
     "Blob",


### PR DESCRIPTION
## Summary

`web-spawn` calls `web_sys::Worker::new_with_options(...)` in [src/wasm/worker.rs:26](web-spawn/src/wasm/worker.rs#L26), but `Worker` was missing.