### PR TITLE
fix(mux): wake driver via shared waker on stream pushes

### DIFF
--- a/mux/mux/src/connection/active.rs
+++ b/mux/mux/src/connection/active.rs
@@ -11,6 +11,7 @@ use futures::{
     channel::mpsc,
     prelude::*,
     stream::{Fuse, SelectAll},
+    task::AtomicWaker,
 };
 use nohash_hasher::IntMap;
 use parking_lot::Mutex;
@@ -39,7 +40,10 @@ pub(crate) struct StreamRegistry {
     id: Id,
     streams: IntMap<StreamId, Arc<Mutex<stream::Shared>>>,
     new_receiver_tx: mpsc::UnboundedSender<TaggedStream<StreamId, mpsc::Receiver<StreamCommand>>>,
-    waker: Option<Waker>,
+    /// Waker for the task driving `Active::poll`. Fired by streams when
+    /// they push a command, and by the registry when a new stream is
+    /// created.
+    driver_waker: Arc<AtomicWaker>,
     config: Arc<Config>,
     rtt: rtt::Rtt,
     accumulated_max_stream_windows: Arc<Mutex<usize>>,
@@ -54,12 +58,13 @@ impl StreamRegistry {
         new_receiver_tx: mpsc::UnboundedSender<
             TaggedStream<StreamId, mpsc::Receiver<StreamCommand>>,
         >,
+        driver_waker: Arc<AtomicWaker>,
     ) -> Self {
         Self {
             id,
             streams: IntMap::default(),
             new_receiver_tx,
-            waker: None,
+            driver_waker,
             config,
             rtt,
             accumulated_max_stream_windows,
@@ -79,6 +84,7 @@ impl StreamRegistry {
         if let Some(existing) = self.streams.get(&stream_id) {
             log::trace!("{}/{}: merging with existing stream", self.id, stream_id);
             let stream = self.make_stream_with_shared(stream_id, user_id, existing.clone());
+            self.driver_waker.wake();
             return Ok(stream);
         }
 
@@ -87,9 +93,7 @@ impl StreamRegistry {
 
         log::debug!("{}: new stream {}", self.id, stream);
 
-        if let Some(waker) = self.waker.take() {
-            waker.wake();
-        }
+        self.driver_waker.wake();
 
         Ok(stream)
     }
@@ -107,11 +111,15 @@ impl StreamRegistry {
             .new_receiver_tx
             .unbounded_send(TaggedStream::new(id, receiver));
 
-        if let Some(waker) = self.waker.take() {
-            waker.wake();
-        }
-
-        Stream::with_shared(id, user_id, self.id, self.config.clone(), sender, shared)
+        Stream::with_shared(
+            id,
+            user_id,
+            self.id,
+            self.config.clone(),
+            sender,
+            shared,
+            self.driver_waker.clone(),
+        )
     }
 
     fn make_stream(&mut self, id: StreamId, user_id: UserId) -> Stream {
@@ -128,6 +136,7 @@ impl StreamRegistry {
             sender,
             self.rtt.clone(),
             self.accumulated_max_stream_windows.clone(),
+            self.driver_waker.clone(),
         )
     }
 
@@ -192,6 +201,8 @@ pub(crate) struct Active<T> {
     new_receiver_rx: mpsc::UnboundedReceiver<TaggedStream<StreamId, mpsc::Receiver<StreamCommand>>>,
     no_streams_waker: Option<Waker>,
 
+    driver_waker: Arc<AtomicWaker>,
+
     pending_read_frame: Option<Frame<()>>,
     pending_write_frame: Option<Frame<()>>,
 }
@@ -226,12 +237,14 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
         let rtt = rtt::Rtt::new();
         let accumulated_max_stream_windows = Arc::new(Mutex::new(0));
         let (new_receiver_tx, new_receiver_rx) = mpsc::unbounded();
+        let driver_waker = Arc::new(AtomicWaker::new());
         let registry = Arc::new(Mutex::new(StreamRegistry::new(
             id,
             config.clone(),
             rtt,
             accumulated_max_stream_windows,
             new_receiver_tx,
+            driver_waker.clone(),
         )));
         Active {
             id,
@@ -241,6 +254,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
             stream_receivers: SelectAll::default(),
             new_receiver_rx,
             no_streams_waker: None,
+            driver_waker,
             pending_read_frame: None,
             pending_write_frame: None,
         }
@@ -304,8 +318,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
                 }
             }
 
-            // Store waker in registry for Handle to wake us
-            self.registry.lock().waker = Some(cx.waker().clone());
+            self.driver_waker.register(cx.waker());
 
             if self.socket.poll_ready_unpin(cx).is_ready() {
                 if let Some(frame) = self.registry.lock().rtt.next_ping() {

--- a/mux/mux/src/connection/active.rs
+++ b/mux/mux/src/connection/active.rs
@@ -184,8 +184,8 @@ pub(crate) enum StreamCommand {
 pub(crate) enum Action {
     /// Nothing to be done.
     None,
-    /// A ping should be answered.
-    Ping(Frame<Ping>),
+    /// A ping with this nonce should be answered with a pong.
+    Pong(u32),
     /// The connection should be terminated.
     Terminate(Frame<GoAway>),
 }
@@ -203,7 +203,20 @@ pub(crate) struct Active<T> {
 
     driver_waker: Arc<AtomicWaker>,
 
-    pending_read_frame: Option<Frame<()>>,
+    /// Nonce of an inbound ping awaiting a reply, if any. Stored as a bare
+    /// nonce (not a built frame) and coalesced — only the most recent ping
+    /// is remembered — so a peer flooding pings costs O(1) memory. The pong
+    /// is constructed lazily once the socket accepts writes.
+    pending_pong: Option<u32>,
+    /// A termination frame produced on a protocol error, awaiting send.
+    pending_terminate: Option<Frame<()>>,
+    /// The current outbound stream frame awaiting the socket.
+    ///
+    /// The driver keeps reading the socket even while these are set. Coupling
+    /// reads to a pending write deadlocks: when both peers' socket send
+    /// buffers fill and each holds a control reply, each stops reading, so
+    /// neither drains the other's buffer. Always draining the read side
+    /// breaks that cycle.
     pending_write_frame: Option<Frame<()>>,
 }
 
@@ -255,7 +268,8 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
             new_receiver_rx,
             no_streams_waker: None,
             driver_waker,
-            pending_read_frame: None,
+            pending_pong: None,
+            pending_terminate: None,
             pending_write_frame: None,
         }
     }
@@ -270,11 +284,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
     /// Gracefully close the connection to the remote.
     pub(super) fn close(self) -> Closing<T> {
         let wait_for_reply = self.config.close_sync;
-        let pending_frames = self
-            .pending_read_frame
-            .into_iter()
-            .chain(self.pending_write_frame)
-            .collect::<PendingFrames>();
+        let pending_frames = self.take_pending_frames();
         Closing::new(
             self.id,
             self.stream_receivers,
@@ -285,13 +295,25 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
         )
     }
 
+    /// Collect any control/data frames not yet flushed to the socket, in
+    /// send-priority order, so a closing connection can drain them.
+    fn take_pending_frames(&self) -> PendingFrames {
+        let pong = self.pending_pong.map(|nonce| {
+            let mut hdr = Header::ping(nonce);
+            hdr.ack();
+            Frame::new(hdr).into()
+        });
+        self.pending_terminate
+            .clone()
+            .into_iter()
+            .chain(pong)
+            .chain(self.pending_write_frame.clone())
+            .collect::<PendingFrames>()
+    }
+
     /// Close the connection without waiting for a reply.
     pub(super) fn close_no_wait(self) -> Closing<T> {
-        let pending_frames = self
-            .pending_read_frame
-            .into_iter()
-            .chain(self.pending_write_frame)
-            .collect::<PendingFrames>();
+        let pending_frames = self.take_pending_frames();
         Closing::new(
             self.id,
             self.stream_receivers,
@@ -326,11 +348,20 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
                     continue;
                 }
 
-                if let Some(frame) = self
-                    .pending_read_frame
-                    .take()
-                    .or_else(|| self.pending_write_frame.take())
-                {
+                // Control frames take priority over stream data: termination
+                // first (we are tearing down), then the opportunistic pong,
+                // built lazily from the stored nonce.
+                if let Some(frame) = self.pending_terminate.take() {
+                    self.socket.start_send_unpin(frame)?;
+                    continue;
+                }
+                if let Some(nonce) = self.pending_pong.take() {
+                    let mut hdr = Header::ping(nonce);
+                    hdr.ack();
+                    self.socket.start_send_unpin(Frame::new(hdr).into())?;
+                    continue;
+                }
+                if let Some(frame) = self.pending_write_frame.take() {
                     self.socket.start_send_unpin(frame)?;
                     continue;
                 }
@@ -373,27 +404,29 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
                 }
             }
 
-            if self.pending_read_frame.is_none() {
-                match self.socket.poll_next_unpin(cx) {
-                    Poll::Ready(Some(frame)) => {
-                        match self.on_frame(frame?)? {
-                            Action::None => {}
-                            Action::Ping(f) => {
-                                log::trace!("{}/{}: pong", self.id, f.header().stream_id());
-                                self.pending_read_frame.replace(f.into());
-                            }
-                            Action::Terminate(f) => {
-                                log::trace!("{}: sending term", self.id);
-                                self.pending_read_frame.replace(f.into());
-                            }
+            // Always drain the read side, even with frames pending for write.
+            // Gating reads on a pending control reply deadlocks two peers whose
+            // socket send buffers are both full.
+            match self.socket.poll_next_unpin(cx) {
+                Poll::Ready(Some(frame)) => {
+                    match self.on_frame(frame?)? {
+                        Action::None => {}
+                        Action::Pong(nonce) => {
+                            log::trace!("{}: pong {}", self.id, nonce);
+                            // Coalesce: only the most recent ping is answered.
+                            self.pending_pong = Some(nonce);
                         }
-                        continue;
+                        Action::Terminate(f) => {
+                            log::trace!("{}: sending term", self.id);
+                            self.pending_terminate = Some(f.into());
+                        }
                     }
-                    Poll::Ready(None) => {
-                        return Poll::Ready(Err(ConnectionError::Closed));
-                    }
-                    Poll::Pending => {}
+                    continue;
                 }
+                Poll::Ready(None) => {
+                    return Poll::Ready(Err(ConnectionError::Closed));
+                }
+                Poll::Pending => {}
             }
 
             return Poll::Pending;
@@ -599,9 +632,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
             return registry.rtt.handle_pong(frame.nonce());
         }
         if stream_id == CONNECTION_ID || registry.streams.contains_key(&stream_id) {
-            let mut hdr = Header::ping(frame.header().nonce());
-            hdr.ack();
-            return Action::Ping(Frame::new(hdr));
+            return Action::Pong(frame.header().nonce());
         }
         log::debug!(
             "{}/{}: ping for unknown stream, possibly dropped earlier",

--- a/mux/mux/src/connection/stream.rs
+++ b/mux/mux/src/connection/stream.rs
@@ -22,6 +22,7 @@ use futures::{
     channel::mpsc,
     io::{AsyncRead, AsyncWrite},
     ready,
+    task::AtomicWaker,
 };
 use parking_lot::{Mutex, MutexGuard};
 use std::{
@@ -70,6 +71,9 @@ pub struct Stream {
     config: Arc<Config>,
     sender: mpsc::Sender<StreamCommand>,
     shared: Arc<Mutex<Shared>>,
+    /// Waker for the connection's poll driver. Fired after every push
+    /// into `sender`.
+    driver_waker: Arc<AtomicWaker>,
 }
 
 impl fmt::Debug for Stream {
@@ -90,6 +94,7 @@ impl fmt::Display for Stream {
 
 impl Stream {
     /// Create a new stream.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         stream_id: StreamId,
         user_id: UserId,
@@ -98,6 +103,7 @@ impl Stream {
         sender: mpsc::Sender<StreamCommand>,
         rtt: rtt::Rtt,
         accumulated_max_stream_windows: Arc<Mutex<usize>>,
+        driver_waker: Arc<AtomicWaker>,
     ) -> Self {
         Self {
             stream_id,
@@ -113,6 +119,7 @@ impl Stream {
                 rtt,
                 config,
             ))),
+            driver_waker,
         }
     }
 
@@ -125,6 +132,7 @@ impl Stream {
         config: Arc<Config>,
         sender: mpsc::Sender<StreamCommand>,
         shared: Arc<Mutex<Shared>>,
+        driver_waker: Arc<AtomicWaker>,
     ) -> Self {
         Self {
             stream_id,
@@ -133,6 +141,7 @@ impl Stream {
             config,
             sender,
             shared,
+            driver_waker,
         }
     }
 
@@ -191,6 +200,7 @@ impl Stream {
         self.sender
             .start_send(cmd)
             .map_err(|_| self.write_zero_err())?;
+        self.driver_waker.wake();
 
         Poll::Ready(Ok(()))
     }
@@ -293,6 +303,7 @@ impl AsyncWrite for Stream {
         self.sender
             .start_send(cmd)
             .map_err(|_| self.write_zero_err())?;
+        self.driver_waker.wake();
         Poll::Ready(Ok(n))
     }
 
@@ -320,9 +331,16 @@ impl AsyncWrite for Stream {
         self.sender
             .start_send(cmd)
             .map_err(|_| self.write_zero_err())?;
+        self.driver_waker.wake();
         self.shared()
             .update_state(self.conn, self.stream_id, State::SendClosed);
         Poll::Ready(Ok(()))
+    }
+}
+
+impl Drop for Stream {
+    fn drop(&mut self) {
+        self.driver_waker.wake();
     }
 }
 


### PR DESCRIPTION
Closes #104 

Streams previously relied on `mpsc::Receiver::recv_task` to wake the connection's poll driver after pushing a command. That slot can be empty when a sender fires it (it is consumed on wake and only re-registered on a `Pending` poll), and the resulting lost wakes could deadlock the driver under parallel pressure.

Add an `AtomicWaker` shared between `Active` and every `Stream`. The poll driver re-arms it each iteration; streams fire it after each `start_send`, on drop, and the registry fires it when a new stream is created. This replaces the previous `Option<Waker>` slot on `StreamRegistry`.