### PR TITLE
fix(mux): free stream slot immediately on drop

### DIFF
--- a/mux/mux/src/connection/active.rs
+++ b/mux/mux/src/connection/active.rs
@@ -18,7 +18,7 @@ use parking_lot::Mutex;
 use std::{
     collections::VecDeque,
     fmt,
-    sync::Arc,
+    sync::{Arc, Weak},
     task::{Context, Poll, Waker},
 };
 
@@ -47,6 +47,13 @@ pub(crate) struct StreamRegistry {
     config: Arc<Config>,
     rtt: rtt::Rtt,
     accumulated_max_stream_windows: Arc<Mutex<usize>>,
+    /// Close frames stashed by [`Stream::drop`], keyed by stream ID. The driver
+    /// sends each one once the stream's already-queued frames have drained,
+    /// preserving ordering.
+    dropped_frames: IntMap<StreamId, Frame<()>>,
+    /// Weak self-reference handed to each [`Stream`] so it can free its slot
+    /// immediately on drop.
+    self_weak: Weak<Mutex<StreamRegistry>>,
 }
 
 impl StreamRegistry {
@@ -68,6 +75,8 @@ impl StreamRegistry {
             config,
             rtt,
             accumulated_max_stream_windows,
+            dropped_frames: IntMap::default(),
+            self_weak: Weak::new(),
         }
     }
 
@@ -119,6 +128,7 @@ impl StreamRegistry {
             sender,
             shared,
             self.driver_waker.clone(),
+            self.self_weak.clone(),
         )
     }
 
@@ -137,6 +147,7 @@ impl StreamRegistry {
             self.rtt.clone(),
             self.accumulated_max_stream_windows.clone(),
             self.driver_waker.clone(),
+            self.self_weak.clone(),
         )
     }
 
@@ -149,6 +160,53 @@ impl StreamRegistry {
             self.rtt.clone(),
             self.config.clone(),
         )))
+    }
+
+    /// Called from [`Stream::drop`] to release a stream's slot.
+    ///
+    /// The slot is freed immediately so it can be reused without waiting for
+    /// the connection driver to observe the closed channel. The appropriate
+    /// close frame (if any) is stashed in `dropped_frames` and sent by the
+    /// driver once the stream's already-queued frames have been drained,
+    /// preserving ordering with respect to the stream's data.
+    pub(super) fn on_stream_dropped(&mut self, stream_id: StreamId) {
+        let Some(s) = self.streams.remove(&stream_id) else {
+            // Already removed (e.g. connection teardown or a merged duplicate).
+            return;
+        };
+
+        log::trace!("{}: removing dropped stream {}", self.id, stream_id);
+        let frame: Option<Frame<()>> = {
+            let mut shared = s.lock();
+            let frame = match shared.update_state(self.id, stream_id, State::Closed) {
+                State::Open => {
+                    let mut header = Header::data(stream_id, 0);
+                    header.rst();
+                    Some(Frame::new(header))
+                }
+                State::RecvClosed => {
+                    let mut header = Header::data(stream_id, 0);
+                    header.fin();
+                    Some(Frame::new(header))
+                }
+                State::SendClosed => None,
+                State::Closed => None,
+            };
+            if let Some(w) = shared.reader.take() {
+                w.wake()
+            }
+            if let Some(w) = shared.writer.take() {
+                w.wake()
+            }
+            frame.map(Into::into)
+        };
+
+        if let Some(frame) = frame {
+            // The frame is *not* sent now: it is emitted by the driver only
+            // after the stream's channel has drained (the `None` signal),
+            // which the dropped `Sender` schedules a wake-up for.
+            self.dropped_frames.insert(stream_id, frame);
+        }
     }
 }
 
@@ -259,6 +317,8 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
             new_receiver_tx,
             driver_waker.clone(),
         )));
+        // Hand each stream a weak self-reference so it can free its slot on drop.
+        registry.lock().self_weak = Arc::downgrade(&registry);
         Active {
             id,
             config,
@@ -391,10 +451,13 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
                         continue;
                     }
                     Poll::Ready(Some((id, None))) => {
-                        if let Some(frame) = self.on_drop_stream(id) {
+                        // The stream was dropped. Its slot was already freed
+                        // eagerly in `Stream::drop`; now that its queued frames
+                        // have drained, emit the stashed close frame (if any).
+                        if let Some(frame) = self.registry.lock().dropped_frames.remove(&id) {
                             log::trace!("{}/{}: sending: {}", self.id, id, frame.header());
                             self.pending_write_frame.replace(frame);
-                        };
+                        }
                         continue;
                     }
                     Poll::Ready(None) => {
@@ -443,40 +506,6 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
             self.stream_receivers.push(receiver);
         }
         Ok(stream)
-    }
-
-    fn on_drop_stream(&mut self, stream_id: StreamId) -> Option<Frame<()>> {
-        let Some(s) = self.registry.lock().streams.remove(&stream_id) else {
-            log::warn!("{}: stream {} not found on drop", self.id, stream_id);
-            return None;
-        };
-
-        log::trace!("{}: removing dropped stream {}", self.id, stream_id);
-        let frame = {
-            let mut shared = s.lock();
-            let frame = match shared.update_state(self.id, stream_id, State::Closed) {
-                State::Open => {
-                    let mut header = Header::data(stream_id, 0);
-                    header.rst();
-                    Some(Frame::new(header))
-                }
-                State::RecvClosed => {
-                    let mut header = Header::data(stream_id, 0);
-                    header.fin();
-                    Some(Frame::new(header))
-                }
-                State::SendClosed => None,
-                State::Closed => None,
-            };
-            if let Some(w) = shared.reader.take() {
-                w.wake()
-            }
-            if let Some(w) = shared.writer.take() {
-                w.wake()
-            }
-            frame
-        };
-        frame.map(Into::into)
     }
 
     fn on_frame(&mut self, frame: Frame<()>) -> Result<Action> {

--- a/mux/mux/src/connection/stream.rs
+++ b/mux/mux/src/connection/stream.rs
@@ -13,7 +13,7 @@
 use crate::{
     Config, DEFAULT_CREDIT,
     chunks::Chunks,
-    connection::{self, StreamCommand, UserId, rtt, rtt::Rtt},
+    connection::{self, StreamCommand, UserId, active::StreamRegistry, rtt, rtt::Rtt},
     frame::{Frame, header::StreamId},
 };
 use flow_control::FlowController;
@@ -28,7 +28,7 @@ use parking_lot::{Mutex, MutexGuard};
 use std::{
     fmt, io,
     pin::Pin,
-    sync::Arc,
+    sync::{Arc, Weak},
     task::{Context, Poll, Waker},
 };
 
@@ -74,6 +74,9 @@ pub struct Stream {
     /// Waker for the connection's poll driver. Fired after every push
     /// into `sender`.
     driver_waker: Arc<AtomicWaker>,
+    /// Weak reference to the owning registry, used to free this stream's slot
+    /// immediately when the stream is dropped.
+    registry: Weak<Mutex<StreamRegistry>>,
 }
 
 impl fmt::Debug for Stream {
@@ -104,6 +107,7 @@ impl Stream {
         rtt: rtt::Rtt,
         accumulated_max_stream_windows: Arc<Mutex<usize>>,
         driver_waker: Arc<AtomicWaker>,
+        registry: Weak<Mutex<StreamRegistry>>,
     ) -> Self {
         Self {
             stream_id,
@@ -120,11 +124,13 @@ impl Stream {
                 config,
             ))),
             driver_waker,
+            registry,
         }
     }
 
     /// Create a stream with existing shared state (for merging with implicit
     /// stream).
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn with_shared(
         stream_id: StreamId,
         user_id: UserId,
@@ -133,6 +139,7 @@ impl Stream {
         sender: mpsc::Sender<StreamCommand>,
         shared: Arc<Mutex<Shared>>,
         driver_waker: Arc<AtomicWaker>,
+        registry: Weak<Mutex<StreamRegistry>>,
     ) -> Self {
         Self {
             stream_id,
@@ -142,6 +149,7 @@ impl Stream {
             sender,
             shared,
             driver_waker,
+            registry,
         }
     }
 
@@ -203,6 +211,21 @@ impl Stream {
         self.driver_waker.wake();
 
         Poll::Ready(Ok(()))
+    }
+}
+
+impl Drop for Stream {
+    fn drop(&mut self) {
+        // Free this stream's slot immediately so a new stream can be opened
+        // without waiting for the connection driver to observe the closed
+        // channel. The driver still emits the close frame once this stream's
+        // queued frames have drained (see `StreamRegistry::on_stream_dropped`).
+        if let Some(registry) = self.registry.upgrade() {
+            registry.lock().on_stream_dropped(self.stream_id);
+        }
+        // Wake the driver so it promptly observes the closed channel and sends
+        // the stashed close frame.
+        self.driver_waker.wake();
     }
 }
 
@@ -335,12 +358,6 @@ impl AsyncWrite for Stream {
         self.shared()
             .update_state(self.conn, self.stream_id, State::SendClosed);
         Poll::Ready(Ok(()))
-    }
-}
-
-impl Drop for Stream {
-    fn drop(&mut self) {
-        self.driver_waker.wake();
     }
 }
 

--- a/mux/test-harness/tests/poll_api.rs
+++ b/mux/test-harness/tests/poll_api.rs
@@ -241,16 +241,25 @@ fn prop_max_streams() {
         // But we need a fresh connection to test this
         let (mut _server2, mut client2) = connected_peers(cfg.clone(), cfg, None).await?;
 
-        // Open max_streams on client2
+        // Open max_streams on client2. The streams must be kept alive: dropping
+        // a stream frees its slot immediately (see issue #108), so the limit is
+        // only reached while the streams are held.
+        let mut client2_streams = Vec::with_capacity(max_streams);
         for i in 0..max_streams {
             let id = format!("stream-{}", i);
-            client2.new_stream(id.as_bytes())?;
+            client2_streams.push(client2.new_stream(id.as_bytes())?);
         }
 
         // Try to open one more stream - should fail
         let extra_id = format!("stream-{}", max_streams);
         let open_result = client2.new_stream(extra_id.as_bytes());
-        Ok(matches!(open_result, Err(ConnectionError::TooManyStreams)))
+        let too_many = matches!(open_result, Err(ConnectionError::TooManyStreams));
+
+        // Dropping a held stream must free a slot so a new one can be opened.
+        drop(client2_streams.pop());
+        let after_drop_ok = client2.new_stream(extra_id.as_bytes()).is_ok();
+
+        Ok(too_many && after_drop_ok)
     }
 
     fn prop(n: usize) -> Result<bool, ConnectionError> {
@@ -464,6 +473,36 @@ fn write_deadlock() {
             )
             .unwrap(),
     );
+}
+
+#[test]
+fn dropping_stream_frees_slot_immediately() {
+    // Regression test for https://github.com/tlsnotary/tlsn-utils/issues/108:
+    // dropping a stream must decrement the stream count immediately, without
+    // waiting for the connection driver's poll loop to observe the closed
+    // channel. Otherwise rapidly opening/closing streams can spuriously hit the
+    // configured limit.
+    let _ = env_logger::try_init();
+
+    let (endpoint, _remote) = futures_ringbuf::Endpoint::pair(256, 256);
+    let mut cfg = Config::default();
+    cfg.set_max_num_streams(1);
+    let mut conn = Connection::new(endpoint, cfg);
+
+    let stream = conn.new_stream(b"one").unwrap();
+
+    // The single slot is taken.
+    assert!(matches!(
+        conn.new_stream(b"two"),
+        Err(ConnectionError::TooManyStreams)
+    ));
+
+    // Drop the stream. Crucially, the connection driver is never polled here.
+    drop(stream);
+
+    // The slot must be available again immediately.
+    conn.new_stream(b"two")
+        .expect("dropping a stream should free its slot immediately");
 }
 
 #[test]


### PR DESCRIPTION
Closes #108

## Problem

The stream limit is enforced by counting entries in the registry map (`streams.len() >= max_num_streams`). A dropped `Stream` only freed its map entry **lazily** — when the connection driver's poll loop eventually observed the closed mpsc channel (the `(id, None)` signal) and called `on_drop_stream`. Under load the driver prioritizes I/O, so closed streams linger in the count and `new_stream` can spuriously return `TooManyStreams` — exactly the failure described in #108 ("the multiplexer driver may be slow to register closed streams").

## Fix

`Stream` now gets a `Drop` impl that frees its slot **synchronously** on the dropping thread:

- `Stream` holds a `Weak<Mutex<StreamRegistry>>`; on drop it calls `StreamRegistry::on_stream_dropped`, which removes the map entry immediately so the count drops right away — no dependency on the driver running.
- The close frame (RST/FIN) is **stashed** in `dropped_frames` and emitted by the driver only once the stream's already-queued frames have drained (the `None` signal), so ordering of data-before-close is preserved.

### Relationship to #105

#105 (`wake driver via shared waker on stream pushes`) reduced the *latency* of the lazy cleanup by waking the driver sooner, but the count was still only decremented when the driver actually ran. This PR makes the decrement **synchronous on drop**, independent of the driver. The two are complementary: #105's `driver_waker.wake()` on drop now also nudges the driver to emit the stashed close frame promptly.

## Behavior change to call out

`prop_max_streams` previously created streams in a loop **without binding them**, so each `Stream` was dropped immediately — it only "reached the limit" because the old lazy cleanup kept dropped streams counted. With this fix, dropped streams free their slot immediately (the intended behavior), so the test now **holds** the streams it opens. The new contract is "max_num_streams *live* streams". The test also asserts that dropping a held stream frees a slot for a new one.

## Tests

- New regression test `dropping_stream_frees_slot_immediately`: opens up to the limit, drops a stream, and opens another **without ever polling the connection driver**. Fails before this change, passes after (and would still fail with only #105, since the driver never runs).
- Full mux + test-harness suite, clippy, and fmt all green.

## Performance

Benchmarked with `benches/concurrent.rs` (criterion, before/after). The fix adds one `parking_lot` registry-lock acquisition on the drop path:

- **gbit-lan (realistic network w/ RTT):** within noise (<1%) across all stream/message counts.
- **unconstrained (pure zero-latency loopback):** up to ~10% on churn-heavy workloads (many streams, little data); single/few-stream and data-heavy workloads unaffected. This is a pure-CPU cost that's invisible once any network latency is present.

A lock-free `AtomicUsize` counter was considered but rejected: it desyncs from the map and reintroduces a same-id-reopen bug (a reopened `user_id` would merge with the still-uncleaned dying stream). Eager map removal is strictly more correct.