### PR TITLE
refactor(mux): new stream backpressure

### DIFF
--- a/mux/mux/src/connection.rs
+++ b/mux/mux/src/connection.rs
@@ -34,7 +34,7 @@ use std::{
 };
 
 pub use active::Handle;
-pub(crate) use active::{Action, StreamCommand};
+pub(crate) use active::{Action, StreamCommand, StreamRegistry};
 pub use stream::Stream;
 
 /// The connection identifier.

--- a/mux/mux/src/connection/active.rs
+++ b/mux/mux/src/connection/active.rs
@@ -38,7 +38,20 @@ use super::{
 /// poll loop and Handle for concurrent stream creation.
 pub(crate) struct StreamRegistry {
     id: Id,
+    /// Streams that are active on the wire and therefore eligible to buffer
+    /// peer data. This is the bounded, peer-relevant resource: its size plus
+    /// the number of owed-but-unflushed close frames must stay at or below
+    /// `config.max_num_streams`.
     streams: IntMap<StreamId, Arc<Mutex<stream::Shared>>>,
+    /// Local handles that have not yet become active on the wire. These never
+    /// buffer peer data and consume no slot until promoted into `streams`.
+    inactive: IntMap<StreamId, Arc<Mutex<stream::Shared>>>,
+    /// Close frames (RST/FIN) owed to the peer by streams that were dropped
+    /// after activation, staged until flushed to the socket. These are never
+    /// dropped and count toward the slot limit.
+    owed_close: IntMap<StreamId, Frame<()>>,
+    /// Wakers of writers blocked waiting for a slot to free.
+    slot_wakers: Vec<Waker>,
     new_receiver_tx: mpsc::UnboundedSender<TaggedStream<StreamId, mpsc::Receiver<StreamCommand>>>,
     /// Waker for the task driving `Active::poll`. Fired by streams when
     /// they push a command, and by the registry when a new stream is
@@ -63,6 +76,9 @@ impl StreamRegistry {
         Self {
             id,
             streams: IntMap::default(),
+            inactive: IntMap::default(),
+            owed_close: IntMap::default(),
+            slot_wakers: Vec::new(),
             new_receiver_tx,
             driver_waker,
             config,
@@ -71,37 +87,115 @@ impl StreamRegistry {
         }
     }
 
-    fn new_stream(&mut self, user_id: &[u8]) -> Result<Stream> {
+    /// The number of slots currently occupied: streams active on the wire
+    /// plus close frames owed to the peer but not yet flushed.
+    fn active_slots(&self) -> usize {
+        self.streams.len() + self.owed_close.len()
+    }
+
+    /// Register a waker to be notified when a slot becomes available.
+    pub(crate) fn register_slot_waker(&mut self, waker: &Waker) {
+        if !self.slot_wakers.iter().any(|w| w.will_wake(waker)) {
+            self.slot_wakers.push(waker.clone());
+        }
+    }
+
+    /// Wake all writers blocked waiting for a slot to free.
+    fn wake_slot_waiters(&mut self) {
+        for waker in self.slot_wakers.drain(..) {
+            waker.wake();
+        }
+    }
+
+    /// Handle a peer reset of `stream_id`: transition it to closed and wake its
+    /// wakers. If no local handle still references the stream (only the map
+    /// holds its `Shared`), remove it, freeing the slot and waking any blocked
+    /// writer so peer churn cannot starve local activations.
+    fn handle_peer_reset(&mut self, id: Id, stream_id: StreamId) {
+        let Some(s) = self.streams.get(&stream_id) else {
+            return;
+        };
+        {
+            let mut shared = s.lock();
+            shared.update_state(id, stream_id, State::Closed);
+            if let Some(w) = shared.reader.take() {
+                w.wake()
+            }
+            if let Some(w) = shared.writer.take() {
+                w.wake()
+            }
+        }
+        if Arc::strong_count(s) == 1 {
+            self.streams.remove(&stream_id);
+            self.wake_slot_waiters();
+        }
+    }
+
+    /// If the peer has already created an active entry for `stream_id`, return
+    /// the canonical [`Shared`] so a local handle can adopt it instead of
+    /// claiming a new slot. Removes any duplicate inactive entry.
+    pub(crate) fn adopt_active(
+        &mut self,
+        stream_id: StreamId,
+    ) -> Option<Arc<Mutex<stream::Shared>>> {
+        let shared = self.streams.get(&stream_id)?.clone();
+        self.inactive.remove(&stream_id);
+        Some(shared)
+    }
+
+    /// Attempt to claim a slot for `shared`, promoting it from the inactive
+    /// set into the active `streams` map. Returns `false` (claiming nothing)
+    /// when no slot is available.
+    pub(crate) fn try_claim_slot(
+        &mut self,
+        stream_id: StreamId,
+        shared: &Arc<Mutex<stream::Shared>>,
+    ) -> bool {
+        if self.active_slots() >= self.config.max_num_streams {
+            return false;
+        }
+        self.inactive.remove(&stream_id);
+        self.streams.insert(stream_id, shared.clone());
+        true
+    }
+
+    fn new_stream(registry: &Arc<Mutex<StreamRegistry>>, user_id: &[u8]) -> Result<Stream> {
+        let mut this = registry.lock();
         let user_id = UserId::new(user_id)?;
         let stream_id = StreamId::new(user_id.as_bytes());
 
-        if self.streams.len() >= self.config.max_num_streams {
-            log::error!("{}: maximum number of streams reached", self.id);
-            return Err(ConnectionError::TooManyStreams);
-        }
+        // Adopt the canonical `Shared` if one already exists, otherwise create
+        // a fresh inactive one. The handle never inserts into `streams`: a
+        // stream becomes slot-eligible only when it first writes.
+        let shared = if let Some(existing) = this.streams.get(&stream_id) {
+            log::trace!("{}/{}: merging with existing stream", this.id, stream_id);
+            existing.clone()
+        } else if let Some(existing) = this.inactive.get(&stream_id) {
+            log::trace!(
+                "{}/{}: merging with existing inactive stream",
+                this.id,
+                stream_id
+            );
+            existing.clone()
+        } else {
+            let shared = this.make_shared();
+            this.inactive.insert(stream_id, shared.clone());
+            shared
+        };
 
-        // Check if stream already exists (created implicitly by remote)
-        if let Some(existing) = self.streams.get(&stream_id) {
-            log::trace!("{}/{}: merging with existing stream", self.id, stream_id);
-            let stream = self.make_stream_with_shared(stream_id, user_id, existing.clone());
-            self.driver_waker.wake();
-            return Ok(stream);
-        }
+        let stream = this.make_stream_with_shared(registry, stream_id, user_id, shared);
 
-        let stream = self.make_stream(stream_id, user_id);
-        self.streams.insert(stream_id, stream.clone_shared());
+        log::debug!("{}: new stream {}", this.id, stream);
 
-        log::debug!("{}: new stream {}", self.id, stream);
-
-        self.driver_waker.wake();
+        this.driver_waker.wake();
 
         Ok(stream)
     }
 
-    /// Create a Stream using existing Shared state (for merging with implicit
-    /// stream).
+    /// Create a Stream using existing Shared state.
     fn make_stream_with_shared(
         &mut self,
+        registry: &Arc<Mutex<StreamRegistry>>,
         id: StreamId,
         user_id: UserId,
         shared: Arc<Mutex<stream::Shared>>,
@@ -118,29 +212,13 @@ impl StreamRegistry {
             self.config.clone(),
             sender,
             shared,
+            registry.clone(),
             self.driver_waker.clone(),
         )
     }
 
-    fn make_stream(&mut self, id: StreamId, user_id: UserId) -> Stream {
-        let (sender, receiver) = mpsc::channel(10);
-        let _ = self
-            .new_receiver_tx
-            .unbounded_send(TaggedStream::new(id, receiver));
-
-        Stream::new(
-            id,
-            user_id,
-            self.id,
-            self.config.clone(),
-            sender,
-            self.rtt.clone(),
-            self.accumulated_max_stream_windows.clone(),
-            self.driver_waker.clone(),
-        )
-    }
-
-    fn make_implicit_stream_shared(&mut self) -> Arc<Mutex<stream::Shared>> {
+    /// Create a fresh inactive `Shared` (not yet active on the wire).
+    fn make_shared(&self) -> Arc<Mutex<stream::Shared>> {
         Arc::new(Mutex::new(stream::Shared::new(
             State::Open,
             crate::DEFAULT_CREDIT,
@@ -149,6 +227,14 @@ impl StreamRegistry {
             self.rtt.clone(),
             self.config.clone(),
         )))
+    }
+
+    /// Create a `Shared` for a stream implicitly created by the peer, marked
+    /// active because inserting it into `streams` claims a slot.
+    fn make_implicit_stream_shared(&mut self) -> Arc<Mutex<stream::Shared>> {
+        let shared = self.make_shared();
+        shared.lock().set_activated();
+        shared
     }
 }
 
@@ -166,7 +252,7 @@ impl Handle {
     ///
     /// The stream ID is computed from the user ID using BLAKE3.
     pub fn new_stream(&self, user_id: &[u8]) -> Result<Stream> {
-        self.registry.lock().new_stream(user_id)
+        StreamRegistry::new_stream(&self.registry, user_id)
     }
 }
 
@@ -282,7 +368,8 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
     }
 
     /// Gracefully close the connection to the remote.
-    pub(super) fn close(self) -> Closing<T> {
+    pub(super) fn close(mut self) -> Closing<T> {
+        self.prepare_close();
         let wait_for_reply = self.config.close_sync;
         let pending_frames = self.take_pending_frames();
         Closing::new(
@@ -295,6 +382,17 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
         )
     }
 
+    /// Prepare to leave the active state: close the stream command receivers so
+    /// any blocked writer observes a closed channel, and wake all writers
+    /// parked on slot availability. Once we leave the active state the driver
+    /// no longer frees slots, so a parked writer would otherwise hang forever.
+    fn prepare_close(&mut self) {
+        for stream in self.stream_receivers.iter_mut() {
+            stream.inner_mut().close();
+        }
+        self.registry.lock().wake_slot_waiters();
+    }
+
     /// Collect any control/data frames not yet flushed to the socket, in
     /// send-priority order, so a closing connection can drain them.
     fn take_pending_frames(&self) -> PendingFrames {
@@ -303,16 +401,26 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
             hdr.ack();
             Frame::new(hdr).into()
         });
+        // Owed close frames are never dropped; flush any still staged.
+        let owed_close = self
+            .registry
+            .lock()
+            .owed_close
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
         self.pending_terminate
             .clone()
             .into_iter()
             .chain(pong)
             .chain(self.pending_write_frame.clone())
+            .chain(owed_close)
             .collect::<PendingFrames>()
     }
 
     /// Close the connection without waiting for a reply.
-    pub(super) fn close_no_wait(self) -> Closing<T> {
+    pub(super) fn close_no_wait(mut self) -> Closing<T> {
+        self.prepare_close();
         let pending_frames = self.take_pending_frames();
         Closing::new(
             self.id,
@@ -372,6 +480,24 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
                 Poll::Pending => {}
             }
 
+            // Flush an owed close frame if one is staged. Moving it out of
+            // `owed_close` into the outbound queue commits it to being sent and
+            // frees the slot it was holding, so any blocked writer is woken.
+            if self.pending_write_frame.is_none() {
+                let mut registry = self.registry.lock();
+                if let Some(stream_id) = registry.owed_close.keys().next().copied() {
+                    let frame = registry
+                        .owed_close
+                        .remove(&stream_id)
+                        .expect("owed close frame should be present");
+                    registry.wake_slot_waiters();
+                    drop(registry);
+                    log::trace!("{}/{}: sending owed close: {}", self.id, stream_id, frame.header());
+                    self.pending_write_frame.replace(frame);
+                    continue;
+                }
+            }
+
             if self.pending_write_frame.is_none() {
                 match self.stream_receivers.poll_next_unpin(cx) {
                     Poll::Ready(Some((_, Some(StreamCommand::SendFrame(frame))))) => {
@@ -391,10 +517,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
                         continue;
                     }
                     Poll::Ready(Some((id, None))) => {
-                        if let Some(frame) = self.on_drop_stream(id) {
-                            log::trace!("{}/{}: sending: {}", self.id, id, frame.header());
-                            self.pending_write_frame.replace(frame);
-                        };
+                        self.on_drop_stream(id);
                         continue;
                     }
                     Poll::Ready(None) => {
@@ -437,7 +560,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
     ///
     /// The stream ID is computed from the user ID using BLAKE3.
     pub(super) fn new_stream(&mut self, user_id: &[u8]) -> Result<Stream> {
-        let stream = self.registry.lock().new_stream(user_id)?;
+        let stream = StreamRegistry::new_stream(&self.registry, user_id)?;
         // Drain new receivers immediately so they're available before poll
         while let Ok(receiver) = self.new_receiver_rx.try_recv() {
             self.stream_receivers.push(receiver);
@@ -445,10 +568,35 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
         Ok(stream)
     }
 
-    fn on_drop_stream(&mut self, stream_id: StreamId) -> Option<Frame<()>> {
-        let Some(s) = self.registry.lock().streams.remove(&stream_id) else {
-            log::warn!("{}: stream {} not found on drop", self.id, stream_id);
-            return None;
+    fn on_drop_stream(&mut self, stream_id: StreamId) {
+        let mut registry = self.registry.lock();
+
+        // Multiple handles may share one `Shared` (a merged user id). Only the
+        // last handle drop reaps the stream; while a sibling handle is alive
+        // (`strong_count > 1`, i.e. more than just the map's reference) the
+        // stream stays active and owes nothing yet.
+        if registry
+            .streams
+            .get(&stream_id)
+            .is_some_and(|s| Arc::strong_count(s) > 1)
+        {
+            return;
+        }
+        if registry
+            .inactive
+            .get(&stream_id)
+            .is_some_and(|s| Arc::strong_count(s) > 1)
+        {
+            return;
+        }
+
+        let Some(s) = registry.streams.remove(&stream_id) else {
+            // A never-activated stream lives only in the inactive set; dropping
+            // it owes the peer nothing and frees no slot.
+            if registry.inactive.remove(&stream_id).is_none() {
+                log::warn!("{}: stream {} not found on drop", self.id, stream_id);
+            }
+            return;
         };
 
         log::trace!("{}: removing dropped stream {}", self.id, stream_id);
@@ -476,7 +624,18 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
             }
             frame
         };
-        frame.map(Into::into)
+
+        // The per-stream buffer/window is freed now (the map's `Arc` is gone).
+        // The slot, however, is held until the owed close frame is flushed: it
+        // is staged in `owed_close` (counting toward the limit) and released
+        // once the driver moves it into the outbound queue. A stream with no
+        // owed frame frees its slot immediately.
+        match frame {
+            Some(frame) => {
+                registry.owed_close.insert(stream_id, frame.into());
+            }
+            None => registry.wake_slot_waiters(),
+        }
     }
 
     fn on_frame(&mut self, frame: Frame<()>) -> Result<Action> {
@@ -496,16 +655,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
         let mut registry = self.registry.lock();
 
         if frame.header().flags().contains(header::RST) {
-            if let Some(s) = registry.streams.get_mut(&stream_id) {
-                let mut shared = s.lock();
-                shared.update_state(self.id, stream_id, State::Closed);
-                if let Some(w) = shared.reader.take() {
-                    w.wake()
-                }
-                if let Some(w) = shared.writer.take() {
-                    w.wake()
-                }
-            }
+            registry.handle_peer_reset(self.id, stream_id);
             return Action::None;
         }
 
@@ -518,24 +668,34 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
         }
 
         // Implicit stream creation: if we receive data for an unknown stream,
-        // create it automatically (the remote opened this stream)
+        // promote a local inactive handle or create it automatically (the
+        // remote opened this stream). Either way it now claims a slot.
         if !registry.streams.contains_key(&stream_id) {
             if stream_id.is_session() {
                 log::error!("{}: data frame for session stream ID 0", self.id);
                 return Action::Terminate(Frame::protocol_error());
             }
 
+            // Only streams active on the wire buffer peer data, so the peer's
+            // buffering demand is bounded by `streams.len()`, not by close
+            // frames we still owe (those hold no receive buffer).
             if registry.streams.len() >= self.config.max_num_streams {
                 log::error!("{}: maximum number of streams reached", self.id);
                 return Action::Terminate(Frame::internal_error());
             }
 
-            log::trace!(
-                "{}/{}: creating implicit stream from remote",
-                self.id,
-                stream_id
-            );
-            let shared = registry.make_implicit_stream_shared();
+            let shared = if let Some(shared) = registry.inactive.remove(&stream_id) {
+                log::trace!("{}/{}: promoting local inactive stream", self.id, stream_id);
+                shared.lock().set_activated();
+                shared
+            } else {
+                log::trace!(
+                    "{}/{}: creating implicit stream from remote",
+                    self.id,
+                    stream_id
+                );
+                registry.make_implicit_stream_shared()
+            };
             registry.streams.insert(stream_id, shared);
         }
 
@@ -567,16 +727,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
         let mut registry = self.registry.lock();
 
         if frame.header().flags().contains(header::RST) {
-            if let Some(s) = registry.streams.get_mut(&stream_id) {
-                let mut shared = s.lock();
-                shared.update_state(self.id, stream_id, State::Closed);
-                if let Some(w) = shared.reader.take() {
-                    w.wake()
-                }
-                if let Some(w) = shared.writer.take() {
-                    w.wake()
-                }
-            }
+            registry.handle_peer_reset(self.id, stream_id);
             return Action::None;
         }
 
@@ -594,17 +745,25 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
                 return Action::None; // Ignore window updates for session
             }
 
+            // Only `streams` entries buffer/grow windows, so gate the peer on
+            // `streams.len()`, not on owed close frames.
             if registry.streams.len() >= self.config.max_num_streams {
                 log::error!("{}: maximum number of streams reached", self.id);
                 return Action::Terminate(Frame::internal_error());
             }
 
-            log::trace!(
-                "{}/{}: creating implicit stream from remote window update",
-                self.id,
-                stream_id
-            );
-            let shared = registry.make_implicit_stream_shared();
+            let shared = if let Some(shared) = registry.inactive.remove(&stream_id) {
+                log::trace!("{}/{}: promoting local inactive stream", self.id, stream_id);
+                shared.lock().set_activated();
+                shared
+            } else {
+                log::trace!(
+                    "{}/{}: creating implicit stream from remote window update",
+                    self.id,
+                    stream_id
+                );
+                registry.make_implicit_stream_shared()
+            };
             registry.streams.insert(stream_id, shared);
         }
 
@@ -647,7 +806,8 @@ impl<T> Active<T> {
     /// Close and drop all `Stream`s and wake any pending `Waker`s.
     pub(super) fn drop_all_streams(&mut self) {
         let mut registry = self.registry.lock();
-        for (id, s) in registry.streams.drain() {
+        let drained: Vec<_> = registry.streams.drain().collect();
+        for (id, s) in drained {
             let mut shared = s.lock();
             shared.update_state(self.id, id, State::Closed);
             if let Some(w) = shared.reader.take() {
@@ -657,5 +817,6 @@ impl<T> Active<T> {
                 w.wake()
             }
         }
+        registry.wake_slot_waiters();
     }
 }

--- a/mux/mux/src/connection/active.rs
+++ b/mux/mux/src/connection/active.rs
@@ -39,9 +39,21 @@ use super::{
 pub(crate) struct StreamRegistry {
     id: Id,
     /// Streams that are active on the wire and therefore eligible to buffer
-    /// peer data. This is the bounded, peer-relevant resource: its size plus
-    /// the number of owed-but-unflushed close frames must stay at or below
-    /// `config.max_num_streams`.
+    /// peer data. This is the bounded, peer-relevant resource: it never holds
+    /// more than `config.max_num_streams` entries, which bounds the peer's
+    /// buffering demand.
+    ///
+    /// Entries the peer has closed (RST/FIN) before any local handle adopted
+    /// them are retained here — together with their buffered data and EOF —
+    /// and keep holding their slot until a local handle claims the id and is
+    /// dropped. Peer data is never discarded: it is the application's
+    /// responsibility to open streams deterministically on both sides so
+    /// every implicitly-created stream is eventually claimed.
+    ///
+    /// Local activation additionally gates on `active_slots()` (this map plus
+    /// `owed_close`), while peer-driven implicit creation gates on the map
+    /// size alone (owed closes hold no receive buffer), so the combined count
+    /// can transiently exceed `max_num_streams` by the number of owed closes.
     streams: IntMap<StreamId, Arc<Mutex<stream::Shared>>>,
     /// Local handles that have not yet become active on the wire. These never
     /// buffer peer data and consume no slot until promoted into `streams`.
@@ -108,26 +120,24 @@ impl StreamRegistry {
     }
 
     /// Handle a peer reset of `stream_id`: transition it to closed and wake its
-    /// wakers. If no local handle still references the stream (only the map
-    /// holds its `Shared`), remove it, freeing the slot and waking any blocked
-    /// writer so peer churn cannot starve local activations.
+    /// wakers.
+    ///
+    /// The entry is retained in `streams` even when no local handle references
+    /// it yet: its buffered data and EOF must survive until a local handle
+    /// opens (adopts) the id, otherwise a late opener would wait forever for
+    /// data the peer already delivered. The entry keeps holding its slot until
+    /// it is claimed and the last handle is dropped.
     fn handle_peer_reset(&mut self, id: Id, stream_id: StreamId) {
         let Some(s) = self.streams.get(&stream_id) else {
             return;
         };
-        {
-            let mut shared = s.lock();
-            shared.update_state(id, stream_id, State::Closed);
-            if let Some(w) = shared.reader.take() {
-                w.wake()
-            }
-            if let Some(w) = shared.writer.take() {
-                w.wake()
-            }
+        let mut shared = s.lock();
+        shared.update_state(id, stream_id, State::Closed);
+        if let Some(w) = shared.reader.take() {
+            w.wake()
         }
-        if Arc::strong_count(s) == 1 {
-            self.streams.remove(&stream_id);
-            self.wake_slot_waiters();
+        if let Some(w) = shared.writer.take() {
+            w.wake()
         }
     }
 
@@ -386,11 +396,28 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
     /// any blocked writer observes a closed channel, and wake all writers
     /// parked on slot availability. Once we leave the active state the driver
     /// no longer frees slots, so a parked writer would otherwise hang forever.
+    ///
+    /// Nothing is delivered to streams once we leave the active state, so every
+    /// stream — active or not — is marked receive-closed and its parked
+    /// readers/writers are woken: a reader drains its buffer and then observes
+    /// EOF, and a writer observes the closed channel, instead of hanging.
     fn prepare_close(&mut self) {
         for stream in self.stream_receivers.iter_mut() {
             stream.inner_mut().close();
         }
-        self.registry.lock().wake_slot_waiters();
+        let mut registry = self.registry.lock();
+        let registry = &mut *registry;
+        for (id, s) in registry.streams.iter().chain(registry.inactive.iter()) {
+            let mut shared = s.lock();
+            shared.update_state(self.id, *id, State::RecvClosed);
+            if let Some(w) = shared.reader.take() {
+                w.wake()
+            }
+            if let Some(w) = shared.writer.take() {
+                w.wake()
+            }
+        }
+        registry.wake_slot_waiters();
     }
 
     /// Collect any control/data frames not yet flushed to the socket, in
@@ -810,8 +837,20 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
 impl<T> Active<T> {
     /// Close and drop all `Stream`s and wake any pending `Waker`s.
     pub(super) fn drop_all_streams(&mut self) {
+        // Close the stream command receivers before waking anyone: a woken
+        // writer re-polls immediately and must observe a closed channel,
+        // otherwise it could re-register on a slot that will never free now
+        // that the driver is gone.
+        for stream in self.stream_receivers.iter_mut() {
+            stream.inner_mut().close();
+        }
         let mut registry = self.registry.lock();
-        let drained: Vec<_> = registry.streams.drain().collect();
+        let registry = &mut *registry;
+        let drained: Vec<_> = registry
+            .streams
+            .drain()
+            .chain(registry.inactive.drain())
+            .collect();
         for (id, s) in drained {
             let mut shared = s.lock();
             shared.update_state(self.id, id, State::Closed);

--- a/mux/mux/src/connection/active.rs
+++ b/mux/mux/src/connection/active.rs
@@ -492,7 +492,12 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
                         .expect("owed close frame should be present");
                     registry.wake_slot_waiters();
                     drop(registry);
-                    log::trace!("{}/{}: sending owed close: {}", self.id, stream_id, frame.header());
+                    log::trace!(
+                        "{}/{}: sending owed close: {}",
+                        self.id,
+                        stream_id,
+                        frame.header()
+                    );
                     self.pending_write_frame.replace(frame);
                     continue;
                 }

--- a/mux/mux/src/connection/stream.rs
+++ b/mux/mux/src/connection/stream.rs
@@ -11,9 +11,9 @@
 // at https://opensource.org/licenses/MIT.
 
 use crate::{
-    Config, DEFAULT_CREDIT,
+    Config,
     chunks::Chunks,
-    connection::{self, StreamCommand, UserId, rtt, rtt::Rtt},
+    connection::{self, StreamCommand, StreamRegistry, UserId, rtt::Rtt},
     frame::{Frame, header::StreamId},
 };
 use flow_control::FlowController;
@@ -69,8 +69,19 @@ pub struct Stream {
     user_id: UserId,
     conn: connection::Id,
     config: Arc<Config>,
-    sender: mpsc::Sender<StreamCommand>,
     shared: Arc<Mutex<Shared>>,
+    /// Declared before `sender` on purpose: fields are dropped in declaration
+    /// order, and dropping `sender` is what signals `(id, None)` to the driver,
+    /// which reaps the stream based on `Arc::strong_count` of `shared`. Were
+    /// this clone of `shared` still alive at that point, the driver could
+    /// observe an inflated count, mistake this for a live sibling handle, and
+    /// skip reaping — leaving the stream's close frame unsent forever.
+    sender: mpsc::Sender<StreamCommand>,
+    /// Handle to the connection's stream registry, used to claim a slot when
+    /// the stream first becomes active on the wire. This points at the
+    /// registry, not at this stream's [`Shared`], so it does not affect the
+    /// `Shared` reference count used by reaping.
+    registry: Arc<Mutex<StreamRegistry>>,
     /// Waker for the connection's poll driver. Fired after every push
     /// into `sender`.
     driver_waker: Arc<AtomicWaker>,
@@ -93,38 +104,8 @@ impl fmt::Display for Stream {
 }
 
 impl Stream {
-    /// Create a new stream.
+    /// Create a stream with existing shared state.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn new(
-        stream_id: StreamId,
-        user_id: UserId,
-        conn: connection::Id,
-        config: Arc<Config>,
-        sender: mpsc::Sender<StreamCommand>,
-        rtt: rtt::Rtt,
-        accumulated_max_stream_windows: Arc<Mutex<usize>>,
-        driver_waker: Arc<AtomicWaker>,
-    ) -> Self {
-        Self {
-            stream_id,
-            user_id,
-            conn,
-            config: config.clone(),
-            sender,
-            shared: Arc::new(Mutex::new(Shared::new(
-                State::Open,
-                DEFAULT_CREDIT,
-                DEFAULT_CREDIT,
-                accumulated_max_stream_windows,
-                rtt,
-                config,
-            ))),
-            driver_waker,
-        }
-    }
-
-    /// Create a stream with existing shared state (for merging with implicit
-    /// stream).
     pub(crate) fn with_shared(
         stream_id: StreamId,
         user_id: UserId,
@@ -132,6 +113,7 @@ impl Stream {
         config: Arc<Config>,
         sender: mpsc::Sender<StreamCommand>,
         shared: Arc<Mutex<Shared>>,
+        registry: Arc<Mutex<StreamRegistry>>,
         driver_waker: Arc<AtomicWaker>,
     ) -> Self {
         Self {
@@ -141,6 +123,7 @@ impl Stream {
             config,
             sender,
             shared,
+            registry,
             driver_waker,
         }
     }
@@ -165,10 +148,6 @@ impl Stream {
 
     pub(crate) fn shared(&self) -> MutexGuard<'_, Shared> {
         self.shared.lock()
-    }
-
-    pub(crate) fn clone_shared(&self) -> Arc<Mutex<Shared>> {
-        self.shared.clone()
     }
 
     fn write_zero_err(&self) -> io::Error {
@@ -203,6 +182,47 @@ impl Stream {
         self.driver_waker.wake();
 
         Poll::Ready(Ok(()))
+    }
+
+    /// Ensure this stream has claimed a slot on the wire before sending its
+    /// first frame to the peer.
+    ///
+    /// Returns `Poll::Ready(())` once the stream holds a slot (or already
+    /// did), and `Poll::Pending` (registering `cx`'s waker) when the slot
+    /// limit is reached and no slot is currently free.
+    fn poll_activate(&mut self, cx: &mut Context) -> Poll<()> {
+        if self.shared.lock().is_activated() {
+            return Poll::Ready(());
+        }
+
+        let mut registry = self.registry.lock();
+
+        if self.shared.lock().is_activated() {
+            return Poll::Ready(());
+        }
+
+        // The peer may have implicitly created an active entry for this id.
+        // Adopt it rather than claim a new slot.
+        if let Some(shared) = registry.adopt_active(self.stream_id) {
+            shared.lock().set_activated();
+            self.shared = shared;
+            return Poll::Ready(());
+        }
+
+        if !registry.try_claim_slot(self.stream_id, &self.shared) {
+            // If the connection is closing the receiver is closed; don't park
+            // on a slot that will never free (the driver is gone). Proceed so
+            // the caller surfaces a write error instead of hanging.
+            if self.sender.is_closed() {
+                return Poll::Ready(());
+            }
+            registry.register_slot_waker(cx.waker());
+            return Poll::Pending;
+        }
+
+        self.shared.lock().set_activated();
+        self.driver_waker.wake();
+        Poll::Ready(())
     }
 }
 
@@ -266,6 +286,10 @@ impl AsyncWrite for Stream {
         cx: &mut Context,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
+        // Writing a stream is what makes it active on the wire; claim a slot
+        // first, applying backpressure if the slot limit is reached.
+        ready!(self.poll_activate(cx));
+
         ready!(
             self.sender
                 .poll_ready(cx)
@@ -318,6 +342,20 @@ impl AsyncWrite for Stream {
             return Poll::Ready(Ok(()));
         }
 
+        // A stream that was never activated has no presence on the wire, so
+        // closing it sends nothing and consumes no slot; we only update the
+        // local state. Check activation under the registry lock so a concurrent
+        // peer-driven promotion (which sets `activated` while holding that lock)
+        // is not missed, matching the lock order in `poll_activate`.
+        {
+            let _registry = self.registry.lock();
+            if !self.shared.lock().is_activated() {
+                self.shared()
+                    .update_state(self.conn, self.stream_id, State::SendClosed);
+                return Poll::Ready(Ok(()));
+            }
+        }
+
         ready!(
             self.sender
                 .poll_ready(cx)
@@ -351,6 +389,10 @@ pub(crate) struct Shared {
     pub(crate) buffer: Chunks,
     pub(crate) reader: Option<Waker>,
     pub(crate) writer: Option<Waker>,
+    /// Whether this stream has claimed a slot on the wire (sent its first
+    /// frame to the peer). Inactive streams consume no slot and emit no
+    /// close frame.
+    activated: bool,
 }
 
 impl Shared {
@@ -374,11 +416,22 @@ impl Shared {
             buffer: Chunks::new(),
             reader: None,
             writer: None,
+            activated: false,
         }
     }
 
     pub(crate) fn state(&self) -> State {
         self.state
+    }
+
+    /// Returns `true` if this stream has claimed a slot on the wire.
+    pub(crate) fn is_activated(&self) -> bool {
+        self.activated
+    }
+
+    /// Mark this stream as having claimed a slot on the wire.
+    pub(crate) fn set_activated(&mut self) {
+        self.activated = true;
     }
 
     /// Update the stream state and return the state before it was updated.

--- a/mux/mux/src/lib.rs
+++ b/mux/mux/src/lib.rs
@@ -142,8 +142,12 @@ impl Config {
     }
 
     /// Set the max. number of streams per connection.
+    ///
+    /// Clamped to at least 1: a stream becomes active on the wire only after
+    /// claiming one of these slots, so a limit of 0 would make every write
+    /// block forever.
     pub fn set_max_num_streams(&mut self, n: usize) -> &mut Self {
-        self.max_num_streams = n;
+        self.max_num_streams = n.max(1);
 
         assert!(
             self.max_connection_receive_window.unwrap_or(usize::MAX)

--- a/mux/mux/src/lib.rs
+++ b/mux/mux/src/lib.rs
@@ -146,6 +146,19 @@ impl Config {
     /// Clamped to at least 1: a stream becomes active on the wire only after
     /// claiming one of these slots, so a limit of 0 would make every write
     /// block forever.
+    ///
+    /// The limit is enforced as write backpressure: a write to a stream that
+    /// is not yet active on the wire blocks until a slot frees. An application
+    /// that holds more than this many streams active concurrently — and needs
+    /// progress on all of them to make progress at all — will therefore
+    /// deadlock; size the limit above the application's maximum number of
+    /// mutually-dependent concurrent streams.
+    ///
+    /// Streams the peer opens implicitly — including ones the peer has already
+    /// closed — hold a slot until a local handle claims them and is dropped;
+    /// their data is never discarded. It is the application's responsibility
+    /// to open streams deterministically on both sides so every peer-opened
+    /// stream is eventually claimed.
     pub fn set_max_num_streams(&mut self, n: usize) -> &mut Self {
         self.max_num_streams = n.max(1);
 

--- a/mux/test-harness/tests/poll_api.rs
+++ b/mux/test-harness/tests/poll_api.rs
@@ -1031,6 +1031,475 @@ fn owed_close_does_not_block_peer_stream_creation() {
     });
 }
 
+/// Data and EOF from a peer that writes to a stream and drops it (RST) before
+/// the local side opens the matching id must be retained: the late local
+/// opener reads the data and observes EOF instead of hanging forever.
+#[test]
+fn peer_writes_and_closes_before_local_open() {
+    let _ = env_logger::try_init();
+
+    fn spawn_driver<T>(mut conn: Connection<T>)
+    where
+        T: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+    {
+        task::spawn(async move {
+            loop {
+                if future::poll_fn(|cx| conn.poll(cx)).await.is_ok() {
+                    break;
+                }
+            }
+        });
+    }
+
+    async fn run_test() {
+        let (a, b) = futures_ringbuf::Endpoint::pair(1 << 20, 1 << 20);
+        let conn_a = Connection::new(a, Config::default());
+        let conn_b = Connection::new(b, Config::default());
+        let (ha, hb) = (conn_a.handle().unwrap(), conn_b.handle().unwrap());
+        spawn_driver(conn_a);
+        spawn_driver(conn_b);
+
+        // Peer B writes to "x" and drops it — fully, before A ever opens "x".
+        {
+            let mut s = hb.new_stream(b"x").unwrap();
+            s.write_all(b"hello").await.unwrap();
+            drop(s); // sends DATA("x") then RST("x")
+        }
+
+        // Let B's frames be processed on A before A opens the id.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        // A opens "x" and reads: the data and EOF must have been retained.
+        let mut s = ha.new_stream(b"x").unwrap();
+        let mut buf = Vec::new();
+        s.read_to_end(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"hello");
+    }
+
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            tokio::time::timeout(std::time::Duration::from_secs(10), run_test())
+                .await
+                .expect("read hung: peer's data/close was lost before local open");
+        });
+}
+
+/// Same as above but with a graceful close (FIN) instead of a reset: the late
+/// local opener reads the data and observes EOF.
+#[test]
+fn peer_writes_and_closes_gracefully_before_local_open() {
+    let _ = env_logger::try_init();
+
+    fn spawn_driver<T>(mut conn: Connection<T>)
+    where
+        T: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+    {
+        task::spawn(async move {
+            loop {
+                if future::poll_fn(|cx| conn.poll(cx)).await.is_ok() {
+                    break;
+                }
+            }
+        });
+    }
+
+    async fn run_test() {
+        let (a, b) = futures_ringbuf::Endpoint::pair(1 << 20, 1 << 20);
+        let conn_a = Connection::new(a, Config::default());
+        let conn_b = Connection::new(b, Config::default());
+        let (ha, hb) = (conn_a.handle().unwrap(), conn_b.handle().unwrap());
+        spawn_driver(conn_a);
+        spawn_driver(conn_b);
+
+        {
+            let mut s = hb.new_stream(b"x").unwrap();
+            s.write_all(b"hello").await.unwrap();
+            s.close().await.unwrap(); // sends DATA("x") then FIN("x")
+            drop(s);
+        }
+
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        let mut s = ha.new_stream(b"x").unwrap();
+        let mut buf = Vec::new();
+        s.read_to_end(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"hello");
+    }
+
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            tokio::time::timeout(std::time::Duration::from_secs(10), run_test())
+                .await
+                .expect("read hung: peer's data/close was lost before local open");
+        });
+}
+
+/// Peer-leads stream churn: the peer completes (writes + drops) many streams
+/// before the local side opens any of them. Every completed stream waits in
+/// its slot until claimed, so every id the local side later opens must
+/// deliver the peer's data and EOF (200 ids stay under the default
+/// `max_num_streams` budget).
+#[test]
+fn peer_leads_stream_churn_data_delivered() {
+    let _ = env_logger::try_init();
+
+    const N: usize = 200;
+
+    fn spawn_driver<T>(mut conn: Connection<T>)
+    where
+        T: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+    {
+        task::spawn(async move {
+            loop {
+                if future::poll_fn(|cx| conn.poll(cx)).await.is_ok() {
+                    break;
+                }
+            }
+        });
+    }
+
+    async fn run_test() {
+        let (a, b) = futures_ringbuf::Endpoint::pair(1 << 20, 1 << 20);
+        let conn_a = Connection::new(a, Config::default());
+        let conn_b = Connection::new(b, Config::default());
+        let (ha, hb) = (conn_a.handle().unwrap(), conn_b.handle().unwrap());
+        spawn_driver(conn_a);
+        spawn_driver(conn_b);
+
+        // B completes every stream before A opens a single one.
+        for k in 0..N {
+            let id = format!("churn-{k}");
+            let mut s = hb.new_stream(id.as_bytes()).unwrap();
+            s.write_all(id.as_bytes()).await.unwrap();
+            drop(s);
+        }
+
+        // A opens each id late and must observe the data and EOF.
+        for k in 0..N {
+            let id = format!("churn-{k}");
+            let mut s = ha.new_stream(id.as_bytes()).unwrap();
+            let mut buf = Vec::new();
+            s.read_to_end(&mut buf).await.unwrap();
+            assert_eq!(buf, id.as_bytes(), "stream {id} lost its data");
+        }
+    }
+
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            tokio::time::timeout(std::time::Duration::from_secs(15), run_test())
+                .await
+                .expect("peer-leads churn deadlocked: completed streams were not retained");
+        });
+}
+
+/// Peer-completed streams that no local handle has claimed sit in their slots
+/// — data intact — until they are claimed; claiming and dropping one frees its
+/// slot, and a peer exceeding the unclaimed budget terminates the connection
+/// loudly rather than having data discarded silently.
+#[test]
+fn unclaimed_peer_streams_hold_slots_until_claimed() {
+    use std::{pin::pin, task::Poll};
+
+    let _ = env_logger::try_init();
+
+    let (server_endpoint, client_endpoint) = futures_ringbuf::Endpoint::pair(8192, 8192);
+    let mut server_cfg = Config::default();
+    server_cfg.set_max_num_streams(2);
+    let mut server = Connection::new(server_endpoint, server_cfg);
+    let mut client = Connection::new(client_endpoint, Config::default());
+
+    let waker = std::task::Waker::noop();
+    let mut cx = std::task::Context::from_waker(waker);
+
+    /// Open a stream on `client`, write its id and drop it (RST), then drive
+    /// both connections so the frames are fully processed.
+    fn complete_stream<T: AsyncRead + AsyncWrite + Unpin>(
+        id: &[u8],
+        client: &mut Connection<T>,
+        server: &mut Connection<T>,
+        cx: &mut std::task::Context<'_>,
+    ) {
+        let mut s = client.new_stream(id).unwrap();
+        assert!(pin!(&mut s).poll_write(cx, id).is_ready());
+        drop(s);
+        for _ in 0..50 {
+            let _ = client.poll(cx);
+            let _ = server.poll(cx);
+        }
+    }
+
+    // The client completes two streams the server has not claimed yet; they
+    // fill the server's entire slot budget and wait there.
+    complete_stream(b"a", &mut client, &mut server, &mut cx);
+    complete_stream(b"b", &mut client, &mut server, &mut cx);
+    assert!(server.poll(&mut cx).is_pending());
+
+    // Claiming one and dropping it frees its slot; the data was retained.
+    {
+        let mut s = server.new_stream(b"a").unwrap();
+        let mut buf = [0u8; 16];
+        match pin!(&mut s).poll_read(&mut cx, &mut buf) {
+            Poll::Ready(Ok(n)) => assert_eq!(&buf[..n], b"a"),
+            other => panic!("expected retained data, got {other:?}"),
+        }
+        match pin!(&mut s).poll_read(&mut cx, &mut buf) {
+            Poll::Ready(Ok(0)) => {}
+            other => panic!("expected EOF, got {other:?}"),
+        }
+    }
+    for _ in 0..50 {
+        let _ = server.poll(&mut cx);
+        let _ = client.poll(&mut cx);
+    }
+
+    // The freed slot admits another peer stream...
+    complete_stream(b"c", &mut client, &mut server, &mut cx);
+    assert!(server.poll(&mut cx).is_pending());
+
+    // ...but exceeding the unclaimed budget terminates the connection: data
+    // is never silently discarded to make room.
+    complete_stream(b"d", &mut client, &mut server, &mut cx);
+    assert!(matches!(server.poll(&mut cx), Poll::Ready(_)));
+}
+
+/// A reader parked on a never-activated stream must be woken with EOF when the
+/// connection is dropped, instead of hanging forever.
+#[test]
+fn parked_reader_on_inactive_stream_woken_on_drop() {
+    use std::{
+        pin::pin,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        task::Poll,
+    };
+
+    let _ = env_logger::try_init();
+
+    struct CountingWake(AtomicUsize);
+    impl futures::task::ArcWake for CountingWake {
+        fn wake_by_ref(arc_self: &Arc<Self>) {
+            arc_self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    let (_server_endpoint, client_endpoint) = futures_ringbuf::Endpoint::pair(8192, 8192);
+    let client = Connection::new(client_endpoint, Config::default());
+
+    let counter = Arc::new(CountingWake(AtomicUsize::new(0)));
+    let waker = futures::task::waker(counter.clone());
+    let mut cx = std::task::Context::from_waker(&waker);
+
+    // Read a stream that was never written: it is inactive and the peer never
+    // sends to it, so the read parks.
+    let mut stream = client
+        .handle()
+        .unwrap()
+        .new_stream(b"never-written")
+        .unwrap();
+    let mut buf = [0u8; 8];
+    assert!(pin!(&mut stream).poll_read(&mut cx, &mut buf).is_pending());
+    assert_eq!(counter.0.load(Ordering::SeqCst), 0);
+
+    // Dropping the connection must wake the parked reader with EOF.
+    drop(client);
+    assert!(
+        counter.0.load(Ordering::SeqCst) > 0,
+        "parked reader was not woken on connection drop"
+    );
+    assert!(matches!(
+        pin!(&mut stream).poll_read(&mut cx, &mut buf),
+        Poll::Ready(Ok(0))
+    ));
+}
+
+/// A reader parked on a never-activated stream must be woken with EOF when the
+/// connection is gracefully closed, instead of hanging forever.
+#[test]
+fn parked_reader_on_inactive_stream_woken_on_close() {
+    use std::{
+        pin::pin,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        task::Poll,
+    };
+
+    let _ = env_logger::try_init();
+
+    struct CountingWake(AtomicUsize);
+    impl futures::task::ArcWake for CountingWake {
+        fn wake_by_ref(arc_self: &Arc<Self>) {
+            arc_self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    let (_server_endpoint, client_endpoint) = futures_ringbuf::Endpoint::pair(8192, 8192);
+    let mut client = Connection::new(client_endpoint, Config::default());
+
+    let counter = Arc::new(CountingWake(AtomicUsize::new(0)));
+    let waker = futures::task::waker(counter.clone());
+    let mut cx = std::task::Context::from_waker(&waker);
+
+    let mut stream = client.new_stream(b"never-written").unwrap();
+    let mut buf = [0u8; 8];
+    assert!(pin!(&mut stream).poll_read(&mut cx, &mut buf).is_pending());
+    assert_eq!(counter.0.load(Ordering::SeqCst), 0);
+
+    // Initiating a graceful close must wake the parked reader with EOF.
+    client.close();
+    assert!(
+        counter.0.load(Ordering::SeqCst) > 0,
+        "parked reader was not woken on connection close"
+    );
+    assert!(matches!(
+        pin!(&mut stream).poll_read(&mut cx, &mut buf),
+        Poll::Ready(Ok(0))
+    ));
+}
+
+/// A reader parked on an active stream must also be woken with EOF on a
+/// graceful close: once the connection leaves the active state nothing is
+/// delivered to streams anymore.
+#[test]
+fn parked_reader_on_active_stream_woken_on_close() {
+    use std::{
+        pin::pin,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        task::Poll,
+    };
+
+    let _ = env_logger::try_init();
+
+    struct CountingWake(AtomicUsize);
+    impl futures::task::ArcWake for CountingWake {
+        fn wake_by_ref(arc_self: &Arc<Self>) {
+            arc_self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    let (_server_endpoint, client_endpoint) = futures_ringbuf::Endpoint::pair(8192, 8192);
+    let mut client = Connection::new(client_endpoint, Config::default());
+
+    let noop = std::task::Waker::noop();
+    let mut noop_cx = std::task::Context::from_waker(noop);
+
+    let counter = Arc::new(CountingWake(AtomicUsize::new(0)));
+    let waker = futures::task::waker(counter.clone());
+    let mut cx = std::task::Context::from_waker(&waker);
+
+    // Activate the stream with a write, then park a read on it.
+    let mut stream = client.new_stream(b"active").unwrap();
+    assert!(pin!(&mut stream).poll_write(&mut noop_cx, b"x").is_ready());
+    let _ = client.poll(&mut noop_cx);
+
+    let mut buf = [0u8; 8];
+    assert!(pin!(&mut stream).poll_read(&mut cx, &mut buf).is_pending());
+    assert_eq!(counter.0.load(Ordering::SeqCst), 0);
+
+    client.close();
+    assert!(
+        counter.0.load(Ordering::SeqCst) > 0,
+        "parked reader was not woken on connection close"
+    );
+    assert!(matches!(
+        pin!(&mut stream).poll_read(&mut cx, &mut buf),
+        Poll::Ready(Ok(0))
+    ));
+}
+
+/// A writer parked on the slot limit when the connection errors out must be
+/// woken and surface an error on its next poll — not re-park on a slot that
+/// will never free.
+///
+/// Note: the precise multi-threaded race this guards (a woken writer
+/// re-polling between `drop_all_streams`'s slot wake and the receivers being
+/// closed, then re-parking forever) cannot be reproduced deterministically
+/// through the public API; it is prevented structurally by `drop_all_streams`
+/// closing the receivers before waking slot waiters. This test pins the
+/// observable contract: the parked writer is woken and errors out.
+#[test]
+fn blocked_writer_is_woken_on_connection_error() {
+    use std::{
+        pin::pin,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+    };
+
+    let _ = env_logger::try_init();
+
+    struct CountingWake(AtomicUsize);
+    impl futures::task::ArcWake for CountingWake {
+        fn wake_by_ref(arc_self: &Arc<Self>) {
+            arc_self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    let (mut server_endpoint, client_endpoint) = futures_ringbuf::Endpoint::pair(8192, 8192);
+    let mut cfg = Config::default();
+    cfg.set_max_num_streams(1);
+    let mut client = Connection::new(client_endpoint, cfg);
+
+    let noop = std::task::Waker::noop();
+    let mut noop_cx = std::task::Context::from_waker(noop);
+
+    let counter = Arc::new(CountingWake(AtomicUsize::new(0)));
+    let waker = futures::task::waker(counter.clone());
+    let mut counted_cx = std::task::Context::from_waker(&waker);
+
+    // A claims the only slot; B parks on the limit.
+    let mut stream_a = client.new_stream(b"a").unwrap();
+    let mut stream_b = client.new_stream(b"b").unwrap();
+    assert!(pin!(&mut stream_a)
+        .poll_write(&mut noop_cx, b"x")
+        .is_ready());
+    let _ = client.poll(&mut noop_cx);
+    assert!(pin!(&mut stream_b)
+        .poll_write(&mut counted_cx, b"y")
+        .is_pending());
+    assert_eq!(counter.0.load(Ordering::SeqCst), 0);
+
+    // Feed garbage into the socket so the connection errors into cleanup.
+    assert!(pin!(&mut server_endpoint)
+        .poll_write(&mut noop_cx, &[0xFF; 64])
+        .is_ready());
+    assert!(matches!(
+        client.poll(&mut noop_cx),
+        std::task::Poll::Ready(Err(_))
+    ));
+
+    // The parked writer must have been woken, and must observe the closed
+    // channel (an error) instead of re-parking forever or writing into the
+    // void.
+    assert!(
+        counter.0.load(Ordering::SeqCst) > 0,
+        "blocked writer was not woken on connection error"
+    );
+    assert!(matches!(
+        pin!(&mut stream_b).poll_write(&mut counted_cx, b"y"),
+        std::task::Poll::Ready(Err(_))
+    ));
+}
+
 /// High-load stress test for the write-gated stream limit.
 ///
 /// Drives far more concurrent streams than the client's slot limit through a
@@ -1138,10 +1607,8 @@ fn high_load_write_gating_no_lost_wakers_or_deadlock() {
 /// contending for far fewer slots than there are workers. Every drop must
 /// reclaim its slot (flushing the owed RST) and wake a blocked writer; if a
 /// single reclamation is lost the limited slots are permanently leaked and the
-/// workers wedge. The server holds no stream handles: it creates each stream
-/// implicitly on the first byte and reaps it on the RST, so a lost RST also
-/// surfaces here as a stall. Tens of thousands of drops make a reap/wakeup
-/// regression overwhelmingly likely to be caught within the timeout.
+/// workers wedge. Tens of thousands of drops make a reap/wakeup regression
+/// overwhelmingly likely to be caught within the timeout.
 #[test]
 fn high_load_stream_churn_no_slot_leak_or_deadlock() {
     let _ = env_logger::try_init();
@@ -1156,10 +1623,13 @@ fn high_load_stream_churn_no_slot_leak_or_deadlock() {
     async fn run_test() {
         let mut client_cfg = Config::default();
         client_cfg.set_max_num_streams(CLIENT_MAX_STREAMS);
-        // The server reaps each implicit stream on its RST, so it never holds
-        // more than the client's in-flight streams; a small margin suffices.
+        // The server never claims the peer-completed streams, so every one of
+        // them sits in a slot — data retained — until the connection ends.
+        // Its budget must therefore cover the full churn volume (and the
+        // window limit, which is asserted against the slot count, is lifted).
         let mut server_cfg = Config::default();
-        server_cfg.set_max_num_streams(8);
+        server_cfg.set_max_connection_receive_window(None);
+        server_cfg.set_max_num_streams(WORKERS * PER_WORKER + 8);
 
         let (mut server, mut client) = connected_peers(server_cfg, client_cfg, None)
             .await

--- a/mux/test-harness/tests/poll_api.rs
+++ b/mux/test-harness/tests/poll_api.rs
@@ -205,63 +205,215 @@ fn concurrent_streams() {
     QuickCheck::new().tests(3).quickcheck(prop as fn(_) -> _)
 }
 
+/// `new_stream` no longer fails when the stream limit is reached: handles are
+/// created locally without bound, and the limit only manifests as write
+/// backpressure once streams become active on the wire.
 #[test]
-fn prop_max_streams() {
-    async fn run_test(n: usize) -> Result<bool, ConnectionError> {
-        let max_streams = n % 100;
-        if max_streams == 0 {
-            return Ok(true); // Skip zero streams
-        }
-        let mut cfg = Config::default();
-        cfg.set_max_num_streams(max_streams);
+fn new_stream_never_errors_with_many_handles() {
+    let _ = env_logger::try_init();
 
-        let (mut server, mut client) = connected_peers(cfg.clone(), cfg.clone(), None).await?;
+    let (server_endpoint, _client_endpoint) = futures_ringbuf::Endpoint::pair(1024, 1024);
+    let mut cfg = Config::default();
+    cfg.set_max_num_streams(2);
+    let mut conn = Connection::new(server_endpoint, cfg);
 
-        // Pre-register streams on server
-        for i in 0..max_streams {
-            let id = format!("stream-{}", i);
-            server.new_stream(id.as_bytes())?;
-        }
+    // Far more handles than max_num_streams; every call succeeds.
+    for i in 0..50 {
+        let id = format!("stream-{}", i);
+        assert!(conn.new_stream(id.as_bytes()).is_ok());
+    }
+}
 
-        // Create streams on client
-        for i in 0..max_streams {
-            let id = format!("stream-{}", i);
-            client.new_stream(id.as_bytes())?;
-        }
+/// Once `max_num_streams` streams are active on the wire, a further write
+/// blocks with `Poll::Pending`, and becomes ready after an active stream is
+/// dropped and its RST is flushed to the peer.
+#[test]
+fn write_gated_pending_at_limit_then_ready_after_slot_frees() {
+    use std::pin::pin;
 
-        // Spawn connection poll loops
-        task::spawn(async move {
-            future::poll_fn(|cx| server.poll(cx)).await.ok();
-        });
-        task::spawn(async move {
-            future::poll_fn(|cx| client.poll(cx)).await.ok();
-        });
+    let _ = env_logger::try_init();
 
-        // Can't open more on a fresh connection since we've already created max streams
-        // But we need a fresh connection to test this
-        let (mut _server2, mut client2) = connected_peers(cfg.clone(), cfg, None).await?;
+    let (server_endpoint, client_endpoint) = futures_ringbuf::Endpoint::pair(8192, 8192);
+    let mut cfg = Config::default();
+    cfg.set_max_num_streams(1);
+    let mut client = Connection::new(client_endpoint, cfg.clone());
+    // A peer to drain frames off the socket so writes can flush.
+    let mut server = Connection::new(server_endpoint, cfg);
 
-        // Open max_streams on client2
-        for i in 0..max_streams {
-            let id = format!("stream-{}", i);
-            client2.new_stream(id.as_bytes())?;
-        }
+    let waker = std::task::Waker::noop();
+    let mut cx = std::task::Context::from_waker(waker);
 
-        // Try to open one more stream - should fail
-        let extra_id = format!("stream-{}", max_streams);
-        let open_result = client2.new_stream(extra_id.as_bytes());
-        Ok(matches!(open_result, Err(ConnectionError::TooManyStreams)))
+    let mut stream_a = client.new_stream(b"a").unwrap();
+    let mut stream_b = client.new_stream(b"b").unwrap();
+
+    // A claims the single slot.
+    assert!(pin!(&mut stream_a).poll_write(&mut cx, b"x").is_ready());
+    let _ = client.poll(&mut cx);
+
+    // B cannot claim a slot: write is pending.
+    assert!(pin!(&mut stream_b).poll_write(&mut cx, b"y").is_pending());
+
+    // Drop A; drive both connections so A's RST is flushed and the slot frees.
+    drop(stream_a);
+    for _ in 0..50 {
+        let _ = client.poll(&mut cx);
+        let _ = server.poll(&mut cx);
     }
 
-    fn prop(n: usize) -> Result<bool, ConnectionError> {
-        tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(run_test(n))
+    // B can now claim the freed slot.
+    assert!(pin!(&mut stream_b).poll_write(&mut cx, b"y").is_ready());
+}
+
+/// A peer cannot make us buffer for more than `max_num_streams` streams: when
+/// the client activates more distinct stream ids than the server's limit, the
+/// server terminates rather than buffering unbounded peer-driven streams.
+#[test]
+fn peer_cannot_exceed_max_streams() {
+    let _ = env_logger::try_init();
+
+    async fn run_test() -> Result<(), ConnectionError> {
+        // The client may open many streams; the server's limit is small.
+        let mut client_cfg = Config::default();
+        client_cfg.set_max_num_streams(64);
+        let mut server_cfg = Config::default();
+        server_cfg.set_max_num_streams(4);
+
+        let (mut server, mut client) = connected_peers(server_cfg, client_cfg, None).await?;
+
+        // Open the streams up-front (always succeeds), then drive the client
+        // poll loop while writing so frames reach the server.
+        let mut streams = Vec::new();
+        for i in 0..32 {
+            let id = format!("peer-{}", i);
+            streams.push(client.new_stream(id.as_bytes())?);
+        }
+
+        let client_task = task::spawn(async move {
+            let drive = future::poll_fn(|cx| client.poll(cx));
+            let write = async move {
+                // Activation happens on first write; hold the handles so no
+                // RST frees a slot. Ignore write errors once the server dies.
+                for (i, mut s) in streams.into_iter().enumerate() {
+                    let _ = s.write_all(&[i as u8]).await;
+                    std::mem::forget(s);
+                }
+                future::pending::<()>().await;
+            };
+            futures::select_biased! {
+                _ = drive.fuse() => {}
+                _ = write.fuse() => {}
+            }
+        });
+
+        // The server must terminate once its limit is exceeded rather than
+        // hang buffering unbounded peer streams.
+        let server_result = tokio::time::timeout(std::time::Duration::from_secs(5), async move {
+            future::poll_fn(|cx| server.poll(cx)).await
+        })
+        .await;
+
+        client_task.abort();
+
+        assert!(
+            matches!(server_result, Ok(Err(_))),
+            "server should terminate on exceeding its stream limit, got {server_result:?}"
+        );
+        Ok(())
     }
 
-    QuickCheck::new().tests(7).quickcheck(prop as fn(_) -> _)
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(run_test())
+        .unwrap();
+}
+
+/// A never-activated stream emits nothing on close or drop and consumes no
+/// slot, so other streams can still be activated at the limit.
+#[test]
+fn never_activated_close_and_drop_emit_nothing() {
+    use std::pin::pin;
+
+    let _ = env_logger::try_init();
+
+    let (_server_endpoint, client_endpoint) = futures_ringbuf::Endpoint::pair(1024, 1024);
+    let mut cfg = Config::default();
+    cfg.set_max_num_streams(1);
+    let mut client = Connection::new(client_endpoint, cfg);
+
+    let waker = std::task::Waker::noop();
+    let mut cx = std::task::Context::from_waker(waker);
+
+    // Create and drop a stream without ever writing; it consumed no slot.
+    let unused = client.new_stream(b"unused").unwrap();
+    drop(unused);
+
+    // Close a never-written stream: returns Ready, sends no close command.
+    let mut to_close = client.new_stream(b"to-close").unwrap();
+    assert!(pin!(&mut to_close).poll_close(&mut cx).is_ready());
+    drop(to_close);
+
+    // Drive the driver; nothing was owed so it stays pending (no work).
+    for _ in 0..10 {
+        let _ = client.poll(&mut cx);
+    }
+
+    // The single slot is still free: a real stream can activate.
+    let mut active = client.new_stream(b"active").unwrap();
+    assert!(pin!(&mut active).poll_write(&mut cx, b"z").is_ready());
+}
+
+/// A local handle created before the peer opens the same stream id adopts the
+/// peer-created entry, so inbound data is delivered without loss.
+#[test]
+fn split_brain_local_then_peer_data_delivers() {
+    let _ = env_logger::try_init();
+    let mut pool = LocalPool::new();
+
+    let (server_endpoint, client_endpoint) = futures_ringbuf::Endpoint::pair(8192, 8192);
+    let mut server = Connection::new(server_endpoint, Config::default());
+    let mut client = Connection::new(client_endpoint, Config::default());
+
+    // Server creates a local handle but does not activate it yet.
+    let mut server_stream = server.new_stream(b"shared-id").unwrap();
+    let mut client_stream = client.new_stream(b"shared-id").unwrap();
+
+    pool.spawner()
+        .spawn_obj(
+            async move {
+                client_stream.write_all(b"hello").await.unwrap();
+                client_stream.close().await.unwrap();
+                loop {
+                    if future::poll_fn(|cx| client.poll(cx)).await.is_ok() {
+                        break;
+                    }
+                }
+            }
+            .boxed()
+            .into(),
+        )
+        .unwrap();
+
+    pool.spawner()
+        .spawn_obj(
+            async move {
+                loop {
+                    if future::poll_fn(|cx| server.poll(cx)).await.is_ok() {
+                        break;
+                    }
+                }
+            }
+            .boxed()
+            .into(),
+        )
+        .unwrap();
+
+    pool.run_until(async {
+        let mut buf = Vec::new();
+        server_stream.read_to_end(&mut buf).await.unwrap();
+        assert_eq!(buf, b"hello");
+    });
 }
 
 #[test]
@@ -569,4 +721,485 @@ fn close_sync() {
 
     // Client should now be able to finish closing
     while client.poll(&mut cx).is_pending() {}
+}
+
+/// A writer blocked on the slot limit is woken when a slot frees, with no lost
+/// wakeup: dropping the only active stream and flushing its RST wakes the
+/// blocked writer's registered waker.
+#[test]
+fn blocked_writer_is_woken_on_slot_free() {
+    use std::{
+        pin::pin,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+    };
+
+    let _ = env_logger::try_init();
+
+    struct CountingWake(AtomicUsize);
+    impl futures::task::ArcWake for CountingWake {
+        fn wake_by_ref(arc_self: &Arc<Self>) {
+            arc_self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    let (server_endpoint, client_endpoint) = futures_ringbuf::Endpoint::pair(8192, 8192);
+    let mut cfg = Config::default();
+    cfg.set_max_num_streams(1);
+    let mut client = Connection::new(client_endpoint, cfg.clone());
+    let mut server = Connection::new(server_endpoint, cfg);
+
+    let noop = std::task::Waker::noop();
+    let mut noop_cx = std::task::Context::from_waker(noop);
+
+    let counter = Arc::new(CountingWake(AtomicUsize::new(0)));
+    let waker = futures::task::waker(counter.clone());
+    let mut counted_cx = std::task::Context::from_waker(&waker);
+
+    let mut stream_a = client.new_stream(b"a").unwrap();
+    let mut stream_b = client.new_stream(b"b").unwrap();
+
+    // A claims the only slot.
+    assert!(pin!(&mut stream_a).poll_write(&mut noop_cx, b"x").is_ready());
+    let _ = client.poll(&mut noop_cx);
+
+    // B blocks, registering its counting waker.
+    assert!(pin!(&mut stream_b)
+        .poll_write(&mut counted_cx, b"y")
+        .is_pending());
+    assert_eq!(counter.0.load(Ordering::SeqCst), 0);
+
+    // Drop A and drive both sides so A's RST flushes and the slot frees.
+    drop(stream_a);
+    for _ in 0..50 {
+        let _ = client.poll(&mut noop_cx);
+        let _ = server.poll(&mut noop_cx);
+    }
+
+    // The blocked writer's waker must have fired.
+    assert!(
+        counter.0.load(Ordering::SeqCst) > 0,
+        "blocked writer was not woken on slot free"
+    );
+    assert!(pin!(&mut stream_b)
+        .poll_write(&mut counted_cx, b"y")
+        .is_ready());
+}
+
+/// A writer parked on the slot limit when the connection is closed must be
+/// woken (and surface an error) rather than hang forever.
+#[test]
+fn blocked_writer_is_woken_on_close() {
+    use std::{
+        pin::pin,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+    };
+
+    let _ = env_logger::try_init();
+
+    struct CountingWake(AtomicUsize);
+    impl futures::task::ArcWake for CountingWake {
+        fn wake_by_ref(arc_self: &Arc<Self>) {
+            arc_self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    let (_server_endpoint, client_endpoint) = futures_ringbuf::Endpoint::pair(8192, 8192);
+    let mut cfg = Config::default();
+    cfg.set_max_num_streams(1);
+    let mut client = Connection::new(client_endpoint, cfg);
+
+    let noop = std::task::Waker::noop();
+    let mut noop_cx = std::task::Context::from_waker(noop);
+
+    let counter = Arc::new(CountingWake(AtomicUsize::new(0)));
+    let waker = futures::task::waker(counter.clone());
+    let mut counted_cx = std::task::Context::from_waker(&waker);
+
+    let mut stream_a = client.new_stream(b"a").unwrap();
+    let mut stream_b = client.new_stream(b"b").unwrap();
+
+    // A claims the only slot; B blocks registering its counting waker.
+    assert!(pin!(&mut stream_a).poll_write(&mut noop_cx, b"x").is_ready());
+    let _ = client.poll(&mut noop_cx);
+    assert!(pin!(&mut stream_b)
+        .poll_write(&mut counted_cx, b"y")
+        .is_pending());
+    assert_eq!(counter.0.load(Ordering::SeqCst), 0);
+
+    // Closing the connection must wake the blocked writer.
+    client.close();
+    assert!(
+        counter.0.load(Ordering::SeqCst) > 0,
+        "blocked writer was not woken on close"
+    );
+
+    // Drive the close handshake so the stream channels are closed, then the
+    // woken writer surfaces an error instead of parking again forever.
+    for _ in 0..10 {
+        let _ = client.poll(&mut counted_cx);
+    }
+    assert!(pin!(&mut stream_b)
+        .poll_write(&mut counted_cx, b"y")
+        .is_ready());
+}
+
+/// Reusing a user id after dropping its activated handle reopens a fresh stream
+/// at the same slot: the new handle can re-activate (the dropped stream's owed
+/// RST is committed to the wire before the slot frees, so it is never dropped)
+/// and writes succeed.
+#[test]
+fn reopen_after_drop_at_limit_succeeds() {
+    use std::pin::pin;
+
+    let _ = env_logger::try_init();
+
+    let (server_endpoint, client_endpoint) = futures_ringbuf::Endpoint::pair(8192, 8192);
+    let mut cfg = Config::default();
+    cfg.set_max_num_streams(1);
+    let mut client = Connection::new(client_endpoint, cfg.clone());
+    let mut server = Connection::new(server_endpoint, cfg);
+
+    let waker = std::task::Waker::noop();
+    let mut cx = std::task::Context::from_waker(waker);
+
+    // Activate X (claims the only slot), then drop it.
+    let mut x = client.new_stream(b"x").unwrap();
+    assert!(pin!(&mut x).poll_write(&mut cx, b"first").is_ready());
+    let _ = client.poll(&mut cx);
+    drop(x);
+
+    // Drive both sides so X's RST flushes and the slot frees.
+    for _ in 0..50 {
+        let _ = client.poll(&mut cx);
+        let _ = server.poll(&mut cx);
+    }
+
+    // Reopen the same id: a fresh stream re-activates and writes successfully.
+    let mut x2 = client.new_stream(b"x").unwrap();
+    assert!(pin!(&mut x2).poll_write(&mut cx, b"second").is_ready());
+}
+
+/// Two local handles sharing one user id share one `Shared`; dropping one must
+/// not reap the active stream while the sibling is alive (which would RST the
+/// peer's side and break the survivor). The survivor keeps reading and writing.
+#[test]
+fn duplicate_handle_not_reaped_until_last_dropped() {
+    let _ = env_logger::try_init();
+    let mut pool = LocalPool::new();
+
+    let (server_endpoint, client_endpoint) = futures_ringbuf::Endpoint::pair(8192, 8192);
+    let mut server = Connection::new(server_endpoint, Config::default());
+    let mut client = Connection::new(client_endpoint, Config::default());
+
+    let mut server_stream = server.new_stream(b"dup").unwrap();
+    // Two client handles for the same user id share one canonical `Shared`.
+    let mut client_a = client.new_stream(b"dup").unwrap();
+    let client_b = client.new_stream(b"dup").unwrap();
+
+    // Server connection poll loop, kept alive for the whole test.
+    pool.spawner()
+        .spawn_obj(
+            async move {
+                loop {
+                    if future::poll_fn(|cx| server.poll(cx)).await.is_ok() {
+                        break;
+                    }
+                }
+            }
+            .boxed()
+            .into(),
+        )
+        .unwrap();
+
+    // Server echoes whatever it reads back on the same stream.
+    pool.spawner()
+        .spawn_obj(
+            async move {
+                let mut buf = [0u8; 3];
+                server_stream.read_exact(&mut buf).await.unwrap();
+                server_stream.write_all(&buf).await.unwrap();
+                server_stream.close().await.unwrap();
+                future::pending::<()>().await;
+            }
+            .boxed()
+            .into(),
+        )
+        .unwrap();
+
+    pool.spawner()
+        .spawn_obj(
+            async move {
+                loop {
+                    if future::poll_fn(|cx| client.poll(cx)).await.is_ok() {
+                        break;
+                    }
+                }
+            }
+            .boxed()
+            .into(),
+        )
+        .unwrap();
+
+    pool.run_until(async {
+        // Activate via A, then drop A while B is still alive. If the drop
+        // reaped the stream it would RST the peer, and the echo read below
+        // would never complete.
+        client_a.write_all(b"abc").await.unwrap();
+        drop(client_a);
+
+        let mut client_b = client_b;
+        let mut buf = [0u8; 3];
+        client_b.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"abc");
+    });
+}
+
+/// A peer opening a brand-new stream is not rejected merely because we hold
+/// owed-but-unflushed close frames: the peer's buffering demand is bounded by
+/// the number of streams active on the wire, not by close frames we still owe.
+/// The server reaches its `max_num_streams` in owed RSTs yet still accepts and
+/// delivers data on a fresh peer-opened stream.
+#[test]
+fn owed_close_does_not_block_peer_stream_creation() {
+    let _ = env_logger::try_init();
+    let mut pool = LocalPool::new();
+
+    let (server_endpoint, client_endpoint) = futures_ringbuf::Endpoint::pair(8192, 8192);
+    let mut server_cfg = Config::default();
+    server_cfg.set_max_num_streams(2);
+    let mut server = Connection::new(server_endpoint, server_cfg);
+    let mut client = Connection::new(client_endpoint, Config::default());
+
+    // Server activates two local-only streams then drops them, leaving up to
+    // two owed RSTs (its full slot budget) staged.
+    let mut s1 = server.new_stream(b"s1").unwrap();
+    let mut s2 = server.new_stream(b"s2").unwrap();
+    // Server's handle for the fresh id, adopting the peer-created entry.
+    let mut server_fresh = server.new_stream(b"fresh").unwrap();
+    let mut client_stream = client.new_stream(b"fresh").unwrap();
+
+    pool.spawner()
+        .spawn_obj(
+            async move {
+                client_stream.write_all(b"hello").await.unwrap();
+                client_stream.close().await.unwrap();
+                loop {
+                    if future::poll_fn(|cx| client.poll(cx)).await.is_ok() {
+                        break;
+                    }
+                }
+            }
+            .boxed()
+            .into(),
+        )
+        .unwrap();
+
+    pool.spawner()
+        .spawn_obj(
+            async move {
+                s1.write_all(b"a").await.unwrap();
+                s2.write_all(b"b").await.unwrap();
+                drop(s1);
+                drop(s2);
+                loop {
+                    if future::poll_fn(|cx| server.poll(cx)).await.is_ok() {
+                        break;
+                    }
+                }
+            }
+            .boxed()
+            .into(),
+        )
+        .unwrap();
+
+    // The server delivers the fresh stream's bytes; if it had terminated on the
+    // (incorrect) owed-close gate, this read would never complete.
+    pool.run_until(async {
+        let mut buf = Vec::new();
+        server_fresh.read_to_end(&mut buf).await.unwrap();
+        assert_eq!(buf, b"hello");
+    });
+}
+
+/// High-load stress test for the write-gated stream limit.
+///
+/// Drives far more concurrent streams than the client's slot limit through a
+/// real multi-threaded runtime, so the great majority of writes must park on
+/// `poll_write` (`Poll::Pending`) and be woken when a slot frees (after the
+/// previous stream's RST is flushed). A lost waker or a deadlock would leave
+/// some stream tasks parked forever; the whole run is wrapped in a timeout so
+/// that surfaces as a failure rather than a hang. Each exchange also verifies
+/// its echo, so the data plane is checked under contention.
+#[test]
+fn high_load_write_gating_no_lost_wakers_or_deadlock() {
+    let _ = env_logger::try_init();
+
+    // Far more streams than the client's limit -> heavy slot churn.
+    const TOTAL_STREAMS: usize = 256;
+    const CLIENT_MAX_STREAMS: usize = 8;
+    // Two frames per stream (split_send_size is 16 KiB), kept under the
+    // 128 KiB window-update threshold so no window updates (and thus no late
+    // frames for an already-reaped stream) are emitted.
+    const PAYLOAD: usize = 32 * 1024;
+
+    async fn run_test() {
+        // The client is tightly slot-limited to force backpressure. The server
+        // has ample slots so it can echo every stream without ever reaching its
+        // own limit (there are only TOTAL_STREAMS distinct ids).
+        let mut client_cfg = Config::default();
+        client_cfg.set_max_num_streams(CLIENT_MAX_STREAMS);
+        let mut server_cfg = Config::default();
+        server_cfg.set_max_num_streams(TOTAL_STREAMS + 8);
+
+        let (mut server, mut client) = connected_peers(server_cfg, client_cfg, None)
+            .await
+            .expect("connect peers");
+
+        // Pre-register a handle per id on both sides so the ids merge.
+        let mut server_streams = Vec::with_capacity(TOTAL_STREAMS);
+        let mut client_streams = Vec::with_capacity(TOTAL_STREAMS);
+        for i in 0..TOTAL_STREAMS {
+            let id = format!("stream-{i}");
+            server_streams.push(server.new_stream(id.as_bytes()).unwrap());
+            client_streams.push(client.new_stream(id.as_bytes()).unwrap());
+        }
+
+        // Drive both connection state machines.
+        task::spawn(async move {
+            future::poll_fn(|cx| server.poll(cx)).await.ok();
+        });
+        task::spawn(async move {
+            future::poll_fn(|cx| client.poll(cx)).await.ok();
+        });
+
+        // Server echoes each stream until the client closes/resets it.
+        let server_tasks: Vec<_> = server_streams
+            .into_iter()
+            .map(|mut stream| {
+                task::spawn(async move {
+                    {
+                        let (mut r, mut w) = AsyncReadExt::split(&mut stream);
+                        futures::io::copy(&mut r, &mut w).await.ok();
+                    }
+                    stream.close().await.ok();
+                })
+            })
+            .collect();
+
+        // Every client stream writes its payload and reads back the echo
+        // concurrently. Only CLIENT_MAX_STREAMS can be active at once; the rest
+        // block in `poll_write` until a slot frees. Dropping the stream (no
+        // graceful close) exercises the owed-RST path: the slot is released
+        // only once that RST is flushed.
+        let payload = vec![0xABu8; PAYLOAD];
+        let client_tasks: Vec<_> = client_streams
+            .into_iter()
+            .map(|mut stream| {
+                let msg = Msg(payload.clone());
+                task::spawn(async move {
+                    send_recv_message(&mut stream, &msg).await.unwrap();
+                    drop(stream);
+                })
+            })
+            .collect();
+
+        for t in client_tasks {
+            t.await.expect("client stream task should complete");
+        }
+        for t in server_tasks {
+            t.await.expect("server stream task should complete");
+        }
+    }
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            tokio::time::timeout(std::time::Duration::from_secs(15), run_test())
+                .await
+                .expect("high-load run timed out: a waker was lost or the mux deadlocked");
+        });
+}
+
+/// High-churn stress test for slot reclamation.
+///
+/// Many worker tasks repeatedly open a stream, write to it, and drop it,
+/// contending for far fewer slots than there are workers. Every drop must
+/// reclaim its slot (flushing the owed RST) and wake a blocked writer; if a
+/// single reclamation is lost the limited slots are permanently leaked and the
+/// workers wedge. The server holds no stream handles: it creates each stream
+/// implicitly on the first byte and reaps it on the RST, so a lost RST also
+/// surfaces here as a stall. Tens of thousands of drops make a reap/wakeup
+/// regression overwhelmingly likely to be caught within the timeout.
+#[test]
+fn high_load_stream_churn_no_slot_leak_or_deadlock() {
+    let _ = env_logger::try_init();
+
+    // A single slot makes a leaked reclamation fatal: if any drop fails to free
+    // its slot, the one slot is gone and every worker wedges on the next
+    // activation, so the bug surfaces as a hang rather than merely slowing down.
+    const CLIENT_MAX_STREAMS: usize = 1;
+    const WORKERS: usize = 16;
+    const PER_WORKER: usize = 8000;
+
+    async fn run_test() {
+        let mut client_cfg = Config::default();
+        client_cfg.set_max_num_streams(CLIENT_MAX_STREAMS);
+        // The server reaps each implicit stream on its RST, so it never holds
+        // more than the client's in-flight streams; a small margin suffices.
+        let mut server_cfg = Config::default();
+        server_cfg.set_max_num_streams(8);
+
+        let (mut server, mut client) = connected_peers(server_cfg, client_cfg, None)
+            .await
+            .expect("connect peers");
+        let handle = client.handle().expect("client handle");
+
+        task::spawn(async move {
+            future::poll_fn(|cx| server.poll(cx)).await.ok();
+        });
+        task::spawn(async move {
+            future::poll_fn(|cx| client.poll(cx)).await.ok();
+        });
+
+        // Many workers contend for the single slot, each opening/writing/
+        // dropping a fresh stream thousands of times. Every drop must reclaim
+        // the slot and wake the next waiter.
+        let mut workers = Vec::with_capacity(WORKERS);
+        for w in 0..WORKERS {
+            let handle = handle.clone();
+            workers.push(task::spawn(async move {
+                for k in 0..PER_WORKER {
+                    // Unique id per stream so every open is a fresh activation.
+                    let id = format!("w{w}-{k}");
+                    let mut stream = handle.new_stream(id.as_bytes()).unwrap();
+                    // First write activates the stream (blocking until the slot
+                    // is free); dropping it then owes an RST and frees the slot.
+                    stream.write_all(&[0xAB]).await.unwrap();
+                    drop(stream);
+                }
+            }));
+        }
+
+        for w in workers {
+            w.await.expect("worker should complete all iterations");
+        }
+    }
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            tokio::time::timeout(std::time::Duration::from_secs(15), run_test())
+                .await
+                .expect("stream churn timed out: a slot was leaked (reap race) or the mux deadlocked");
+        });
 }

--- a/mux/test-harness/tests/poll_api.rs
+++ b/mux/test-harness/tests/poll_api.rs
@@ -762,7 +762,9 @@ fn blocked_writer_is_woken_on_slot_free() {
     let mut stream_b = client.new_stream(b"b").unwrap();
 
     // A claims the only slot.
-    assert!(pin!(&mut stream_a).poll_write(&mut noop_cx, b"x").is_ready());
+    assert!(pin!(&mut stream_a)
+        .poll_write(&mut noop_cx, b"x")
+        .is_ready());
     let _ = client.poll(&mut noop_cx);
 
     // B blocks, registering its counting waker.
@@ -825,7 +827,9 @@ fn blocked_writer_is_woken_on_close() {
     let mut stream_b = client.new_stream(b"b").unwrap();
 
     // A claims the only slot; B blocks registering its counting waker.
-    assert!(pin!(&mut stream_a).poll_write(&mut noop_cx, b"x").is_ready());
+    assert!(pin!(&mut stream_a)
+        .poll_write(&mut noop_cx, b"x")
+        .is_ready());
     let _ = client.poll(&mut noop_cx);
     assert!(pin!(&mut stream_b)
         .poll_write(&mut counted_cx, b"y")
@@ -1200,6 +1204,8 @@ fn high_load_stream_churn_no_slot_leak_or_deadlock() {
         .block_on(async {
             tokio::time::timeout(std::time::Duration::from_secs(15), run_test())
                 .await
-                .expect("stream churn timed out: a slot was leaked (reap race) or the mux deadlocked");
+                .expect(
+                    "stream churn timed out: a slot was leaked (reap race) or the mux deadlocked",
+                );
         });
 }

--- a/mux/test-harness/tests/poll_api.rs
+++ b/mux/test-harness/tests/poll_api.rs
@@ -306,7 +306,11 @@ fn peer_cannot_exceed_max_streams() {
         });
 
         // The server must terminate once its limit is exceeded rather than
-        // hang buffering unbounded peer streams.
+        // hang buffering unbounded peer streams. Whether the poll resolves to
+        // `Ok` or `Err` depends on how the socket teardown races after the
+        // server sends its GoAway (clean EOF maps to `Ok(())`, a failed write
+        // on the dead socket to `Err`); the property under test is that the
+        // connection ends instead of timing out.
         let server_result = tokio::time::timeout(std::time::Duration::from_secs(5), async move {
             future::poll_fn(|cx| server.poll(cx)).await
         })
@@ -315,7 +319,7 @@ fn peer_cannot_exceed_max_streams() {
         client_task.abort();
 
         assert!(
-            matches!(server_result, Ok(Err(_))),
+            server_result.is_ok(),
             "server should terminate on exceeding its stream limit, got {server_result:?}"
         );
         Ok(())

--- a/mux/test-harness/tests/poll_api.rs
+++ b/mux/test-harness/tests/poll_api.rs
@@ -1204,6 +1204,92 @@ fn peer_leads_stream_churn_data_delivered() {
         });
 }
 
+/// Paced concurrent churn: many short request/response round-trips on fresh ids
+/// with bounded concurrency, both peers opening the same ids (so they merge).
+/// Each request awaits its response, so the load is self-paced (no unbounded
+/// flooding). Exercises implicit-create + merge + close delivery under churn —
+/// the load shape of tlsn's MPC-TLS usage.
+#[test]
+fn concurrent_churn_request_response() {
+    use tlsn_mux::Handle;
+
+    let _ = env_logger::try_init();
+
+    const N: usize = 6000;
+    const CONC: usize = 64;
+
+    fn spawn_driver<T>(mut conn: Connection<T>)
+    where
+        T: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+    {
+        task::spawn(async move {
+            loop {
+                if future::poll_fn(|cx| conn.poll(cx)).await.is_ok() {
+                    break;
+                }
+            }
+        });
+    }
+
+    // Requester: open id, send a byte, read the echo, close.
+    async fn requester(handle: Handle, n: usize, conc: usize) {
+        futures::stream::iter(0..n)
+            .for_each_concurrent(conc, |i| {
+                let handle = handle.clone();
+                async move {
+                    let id = (i as u64).to_le_bytes();
+                    let mut s = handle.new_stream(&id).unwrap();
+                    s.write_all(&[0xAB]).await.unwrap();
+                    let mut buf = [0u8; 1];
+                    s.read_exact(&mut buf).await.unwrap();
+                    assert_eq!(buf[0], 0xAB);
+                    drop(s);
+                }
+            })
+            .await;
+    }
+
+    // Responder: open the same id, read the byte, echo it, close.
+    async fn responder(handle: Handle, n: usize, conc: usize) {
+        futures::stream::iter(0..n)
+            .for_each_concurrent(conc, |i| {
+                let handle = handle.clone();
+                async move {
+                    let id = (i as u64).to_le_bytes();
+                    let mut s = handle.new_stream(&id).unwrap();
+                    let mut buf = [0u8; 1];
+                    if s.read_exact(&mut buf).await.is_ok() {
+                        let _ = s.write_all(&buf).await;
+                    }
+                    drop(s);
+                }
+            })
+            .await;
+    }
+
+    async fn run_test() {
+        let (a, b) = futures_ringbuf::Endpoint::pair(1 << 22, 1 << 22);
+        let conn_a = Connection::new(a, Config::default());
+        let conn_b = Connection::new(b, Config::default());
+        let (ha, hb) = (conn_a.handle().unwrap(), conn_b.handle().unwrap());
+        spawn_driver(conn_a);
+        spawn_driver(conn_b);
+
+        future::join(requester(ha, N, CONC), responder(hb, N, CONC)).await;
+    }
+
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            tokio::time::timeout(std::time::Duration::from_secs(30), run_test())
+                .await
+                .expect("churn did not complete within 30s (deadlock/regression)");
+        });
+}
+
 /// Peer-completed streams that no local handle has claimed sit in their slots
 /// — data intact — until they are claimed; claiming and dropping one frees its
 /// slot, and a peer exceeding the unclaimed budget terminates the connection


### PR DESCRIPTION
## Summary

Reworks how `tlsn-mux` enforces the per-connection stream limit
(`max_num_streams`). The limit is now applied as **write backpressure on
streams that are active on the wire**, instead of as an error returned when
opening a stream.

## Behavior

- **Opening a stream never fails on the limit.** `Connection::new_stream` and
  `Handle::new_stream` always return a handle (they still validate the user
  ID). Holding handles is cheap, and the number of handles is unbounded and
  caller-managed.
- **The limit is enforced on write.** A stream consumes one of the
  `max_num_streams` slots only when it first becomes active on the wire (its
  first write). While all slots are occupied, `Stream::poll_write` returns
  `Poll::Pending` and is woken when a slot frees. A stream that is never
  written to consumes no slot and sends nothing on the wire (including on
  close/drop).
- **Peer-driven memory stays bounded.** Only streams active on the wire can
  buffer inbound data, and that set is capped at `max_num_streams`, so a remote
  peer cannot drive unbounded memory growth. The per-connection receive-window
  bound is preserved.
- **Close frames are never dropped.** A slot is held from activation until the
  stream's owed `RST`/`FIN` has been flushed, so the peer is always notified of
  a closure and the number of outstanding close frames is bounded.
- **`Config::set_max_num_streams` clamps its argument to at least 1** (a limit
  of 0 would block every write indefinitely).
- `ConnectionError::TooManyStreams` is retained for API compatibility but is no
  longer produced by the library.

## Correctness

Stream reclamation is safe under concurrent load: a stream is reclaimed exactly
once on its last handle drop, its owed close frame is delivered in order after
its buffered data, and writers blocked on the slot limit are reliably woken
when a slot frees (on stream drop, owed-frame flush, peer reset, or connection
close) — no lost wakeups or deadlocks. Merged/duplicate user IDs,
peer-initiated (implicit) streams, half-close, and graceful close are all
handled.

## Testing

- Unit/integration tests for the new semantics: open-never-errors, write
  gating (`Pending` at the limit → `Ready` after a slot frees), bounded
  peer-driven stream creation, single-canonical-stream on local/peer races,
  never-activated close/drop, owed-close not blocking peer streams,
  duplicate-handle reclamation, and blocked-writer wakeups (slot-free and
  connection-close paths).
- High-load concurrency/stress tests that drive far more concurrent streams
  than the slot limit, with deadlock watchdogs, asserting no lost wakers or
  deadlocks under contention.
- All tests pass.